### PR TITLE
Chore: improved sample input vars

### DIFF
--- a/examples/pokeapi/example.tf
+++ b/examples/pokeapi/example.tf
@@ -23,16 +23,19 @@ variable "google_client_id" {
 }
 
 variable "google_client_secret" {
+  description = "The client secret to use for writing data to Google Sheets."
   type = string
   sensitive = true
 }
 
 variable "google_client_refresh_token" {
+  description = "The refresh token to use for writing data to Google Sheets."
   type = string
   sensitive = true
 }
 
 variable "google_spreadsheet_id" {
+  description = "The ID of the Google Sheet to load data into."
   type = string
   sensitive = false
 }

--- a/examples/pokeapi/example.tf
+++ b/examples/pokeapi/example.tf
@@ -13,6 +13,7 @@ provider "airbyte" {
 
 variable "key" {
   description = "The Airbyte API Key to use when authenticating to the Airbyte service."
+  sensitive = true
   type = string
 }
 

--- a/examples/pokeapi/example.tf
+++ b/examples/pokeapi/example.tf
@@ -12,23 +12,29 @@ provider "airbyte" {
 }
 
 variable "key" {
+  description = "The Airbyte API Key to use when authenticating to the Airbyte service."
   type = string
 }
 
 variable "google_client_id" {
-  type = string
-}
-
-variable "google_spreadsheet_id" {
+  description = "The Client ID to use when writing data to Google Sheets."
+  sensitive = true
   type = string
 }
 
 variable "google_client_secret" {
   type = string
+  sensitive = true
 }
 
 variable "google_client_refresh_token" {
   type = string
+  sensitive = true
+}
+
+variable "google_spreadsheet_id" {
+  type = string
+  sensitive = false
 }
 
 resource "airbyte_workspace" "my_workspace" {


### PR DESCRIPTION
This PR suggests two relatively small non-breaking changes to the sample project:

1. Mark secrets with "sensitive = true". This informs terraform to treat them as sensitive, for instance: preventing their echoing to the CLI during user entry and in log files.
2. Add prompts (descriptions) to each variable input, which just makes those inputs more obvious to the user if typing in via the terraform CLI built-in Terraform prompts.



<details>
<summary>Screenshots:</summary>

![image](https://github.com/airbytehq/terraform-provider-airbyte/assets/18150651/2bde657b-b339-493a-8666-f5a9ab530e23)

![image](https://github.com/airbytehq/terraform-provider-airbyte/assets/18150651/ed353550-a89e-4305-87a2-a397ca8ab7ec)

</details>
