### PR TITLE
Add newest non breaking schema updates behavior enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "0.3.0"
+      version = "0.3.1"
     }
   }
 }

--- a/airbyte.yaml
+++ b/airbyte.yaml
@@ -21493,6 +21493,8 @@ components:
       enum:
       - "ignore"
       - "disable_connection"
+      - "propagate_columns"
+      - "propagate_fully"
       default: "ignore"
     NamespaceDefinitionEnumNoDefault:
       type: "string"
@@ -21508,6 +21510,8 @@ components:
       enum:
       - "ignore"
       - "disable_connection"
+      - "propagate_columns"
+      - "propagate_fully"
     DestinationResponse:
       title: "Root Type for DestinationResponse"
       description: "Provides details of a single destination."

--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -34,7 +34,7 @@ data "airbyte_connection" "my_connection" {
 - `namespace_definition` (String) must be one of ["source", "destination", "custom_format"]
 Define the location where the data will be stored in the destination
 - `namespace_format` (String) Used when namespaceDefinition is 'custom_format'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
-- `non_breaking_schema_updates_behavior` (String) must be one of ["ignore", "disable_connection"]
+- `non_breaking_schema_updates_behavior` (String) must be one of ["ignore", "disable_connection", "propagate_columns", "propagate_fully"]
 Set how Airbyte handles syncs when it detects a non-breaking schema change in the source
 - `prefix` (String) Prefix that will be prepended to the name of each stream when it is written to the destination (ex. “airbyte_” causes “projects” => “airbyte_projects”).
 - `schedule` (Attributes) schedule for when the the connection should run, per the schedule type (see [below for nested schema](#nestedatt--schedule))

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "0.3.0"
+      version = "0.3.1"
     }
   }
 }

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -35,7 +35,7 @@ resource "airbyte_connection" "my_connection" {
   name                                 = "Wilfred Wolff"
   namespace_definition                 = "custom_format"
   namespace_format                     = SOURCE_NAMESPACE
-  non_breaking_schema_updates_behavior = "ignore"
+  non_breaking_schema_updates_behavior = "disable_connection"
   prefix                               = "...my_prefix..."
   schedule = {
     basic_timing    = "...my_basic_timing..."
@@ -63,7 +63,7 @@ resource "airbyte_connection" "my_connection" {
 - `namespace_definition` (String) must be one of ["source", "destination", "custom_format"]
 Define the location where the data will be stored in the destination
 - `namespace_format` (String) Used when namespaceDefinition is 'custom_format'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
-- `non_breaking_schema_updates_behavior` (String) must be one of ["ignore", "disable_connection"]
+- `non_breaking_schema_updates_behavior` (String) must be one of ["ignore", "disable_connection", "propagate_columns", "propagate_fully"]
 Set how Airbyte handles syncs when it detects a non-breaking schema change in the source
 - `prefix` (String) Prefix that will be prepended to the name of each stream when it is written to the destination (ex. “airbyte_” causes “projects” => “airbyte_projects”).
 - `schedule` (Attributes) schedule for when the the connection should run, per the schedule type (see [below for nested schema](#nestedatt--schedule))

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "0.3.0"
+      version = "0.3.1"
     }
   }
 }

--- a/examples/resources/airbyte_connection/resource.tf
+++ b/examples/resources/airbyte_connection/resource.tf
@@ -20,7 +20,7 @@ resource "airbyte_connection" "my_connection" {
   name                                 = "Wilfred Wolff"
   namespace_definition                 = "custom_format"
   namespace_format                     = SOURCE_NAMESPACE
-  non_breaking_schema_updates_behavior = "ignore"
+  non_breaking_schema_updates_behavior = "disable_connection"
   prefix                               = "...my_prefix..."
   schedule = {
     basic_timing    = "...my_basic_timing..."

--- a/files.gen
+++ b/files.gen
@@ -2629,8 +2629,8 @@ internal/sdk/pkg/models/shared/workspacecreaterequest.go
 internal/sdk/pkg/models/shared/workspacesresponse.go
 internal/sdk/pkg/models/shared/workspaceupdaterequest.go
 internal/sdk/pkg/models/shared/security.go
-internal/sdk/pkg/models/shared/connectionresponseroottypeforconnectionresponse.go
 internal/sdk/pkg/models/shared/workspaceresponseroottypeforworkspaceresponse.go
+internal/sdk/pkg/models/shared/connectionresponseroottypeforconnectionresponse.go
 USAGE.md
 internal/provider/provider.go
 examples/provider/provider.tf

--- a/gen.yaml
+++ b/gen.yaml
@@ -10,6 +10,6 @@ features:
     globalServerURLs: 2.81.1
     includes: 2.81.1
 terraform:
-  version: 0.3.0
+  version: 0.3.1
   author: airbytehq
   packageName: airbyte

--- a/internal/provider/connection_data_source.go
+++ b/internal/provider/connection_data_source.go
@@ -140,9 +140,11 @@ func (r *ConnectionDataSource) Schema(ctx context.Context, req datasource.Schema
 					stringvalidator.OneOf(
 						"ignore",
 						"disable_connection",
+						"propagate_columns",
+						"propagate_fully",
 					),
 				},
-				MarkdownDescription: `must be one of ["ignore", "disable_connection"]` + "\n" +
+				MarkdownDescription: `must be one of ["ignore", "disable_connection", "propagate_columns", "propagate_fully"]` + "\n" +
 					`Set how Airbyte handles syncs when it detects a non-breaking schema change in the source`,
 			},
 			"prefix": schema.StringAttribute{

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -192,9 +192,11 @@ func (r *ConnectionResource) Schema(ctx context.Context, req resource.SchemaRequ
 					stringvalidator.OneOf(
 						"ignore",
 						"disable_connection",
+						"propagate_columns",
+						"propagate_fully",
 					),
 				},
-				MarkdownDescription: `must be one of ["ignore", "disable_connection"]` + "\n" +
+				MarkdownDescription: `must be one of ["ignore", "disable_connection", "propagate_columns", "propagate_fully"]` + "\n" +
 					`Set how Airbyte handles syncs when it detects a non-breaking schema change in the source`,
 			},
 			"prefix": schema.StringAttribute{

--- a/internal/sdk/pkg/models/shared/nonbreakingschemaupdatesbehaviorenum.go
+++ b/internal/sdk/pkg/models/shared/nonbreakingschemaupdatesbehaviorenum.go
@@ -13,6 +13,8 @@ type NonBreakingSchemaUpdatesBehaviorEnum string
 const (
 	NonBreakingSchemaUpdatesBehaviorEnumIgnore            NonBreakingSchemaUpdatesBehaviorEnum = "ignore"
 	NonBreakingSchemaUpdatesBehaviorEnumDisableConnection NonBreakingSchemaUpdatesBehaviorEnum = "disable_connection"
+	NonBreakingSchemaUpdatesBehaviorEnumPropagateColumns  NonBreakingSchemaUpdatesBehaviorEnum = "propagate_columns"
+	NonBreakingSchemaUpdatesBehaviorEnumPropagateFully    NonBreakingSchemaUpdatesBehaviorEnum = "propagate_fully"
 )
 
 func (e NonBreakingSchemaUpdatesBehaviorEnum) ToPointer() *NonBreakingSchemaUpdatesBehaviorEnum {
@@ -28,6 +30,10 @@ func (e *NonBreakingSchemaUpdatesBehaviorEnum) UnmarshalJSON(data []byte) error 
 	case "ignore":
 		fallthrough
 	case "disable_connection":
+		fallthrough
+	case "propagate_columns":
+		fallthrough
+	case "propagate_fully":
 		*e = NonBreakingSchemaUpdatesBehaviorEnum(v)
 		return nil
 	default:

--- a/internal/sdk/pkg/models/shared/nonbreakingschemaupdatesbehaviorenumnodefault.go
+++ b/internal/sdk/pkg/models/shared/nonbreakingschemaupdatesbehaviorenumnodefault.go
@@ -13,6 +13,8 @@ type NonBreakingSchemaUpdatesBehaviorEnumNoDefault string
 const (
 	NonBreakingSchemaUpdatesBehaviorEnumNoDefaultIgnore            NonBreakingSchemaUpdatesBehaviorEnumNoDefault = "ignore"
 	NonBreakingSchemaUpdatesBehaviorEnumNoDefaultDisableConnection NonBreakingSchemaUpdatesBehaviorEnumNoDefault = "disable_connection"
+	NonBreakingSchemaUpdatesBehaviorEnumNoDefaultPropagateColumns  NonBreakingSchemaUpdatesBehaviorEnumNoDefault = "propagate_columns"
+	NonBreakingSchemaUpdatesBehaviorEnumNoDefaultPropagateFully    NonBreakingSchemaUpdatesBehaviorEnumNoDefault = "propagate_fully"
 )
 
 func (e NonBreakingSchemaUpdatesBehaviorEnumNoDefault) ToPointer() *NonBreakingSchemaUpdatesBehaviorEnumNoDefault {
@@ -28,6 +30,10 @@ func (e *NonBreakingSchemaUpdatesBehaviorEnumNoDefault) UnmarshalJSON(data []byt
 	case "ignore":
 		fallthrough
 	case "disable_connection":
+		fallthrough
+	case "propagate_columns":
+		fallthrough
+	case "propagate_fully":
 		*e = NonBreakingSchemaUpdatesBehaviorEnumNoDefault(v)
 		return nil
 	default:

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -122,7 +122,7 @@ func New(opts ...SDKOption) *SDK {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "terraform",
 			OpenAPIDocVersion: "1.0.0",
-			SDKVersion:        "0.3.0",
+			SDKVersion:        "0.3.1",
 			GenVersion:        "2.83.3",
 		},
 	}


### PR DESCRIPTION
Update terraform provider to allow for all `NonBreakingSchemaUpdatesBehaviorEnum` options which include:
      - "ignore"
      - "disable_connection"
      - "propagate_columns"
      - "propagate_fully"