### PR TITLE
fix: broken non-required, constant fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.tfstate*
 .DS_Store
 *.tfvars
+.idea

--- a/gen.yaml
+++ b/gen.yaml
@@ -8,7 +8,7 @@ generation:
 features:
   terraform:
     additionalProperties: 0.1.2
-    constsAndDefaults: 0.1.1
+    constsAndDefaults: 0.1.2
     core: 3.5.1
     globalSecurity: 2.81.1
     globalServerURLs: 2.82.1

--- a/internal/sdk/pkg/utils/json.go
+++ b/internal/sdk/pkg/utils/json.go
@@ -50,7 +50,7 @@ func MarshalJSON(v interface{}, tag reflect.StructTag, topLevel bool) ([]byte, e
 				}
 			}
 
-			if isNil(field.Type, fieldVal) {
+			if isNil(field.Type, fieldVal) && field.Tag.Get("const") == "" {
 				if omitEmpty {
 					continue
 				}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -147,8 +147,8 @@ func New(opts ...SDKOption) *SDK {
 			Language:          "go",
 			OpenAPIDocVersion: "1.0.0",
 			SDKVersion:        "0.3.5",
-			GenVersion:        "2.206.3",
-			UserAgent:         "speakeasy-sdk/go 0.3.5 2.206.3 1.0.0 airbyte",
+			GenVersion:        "2.210.3",
+			UserAgent:         "speakeasy-sdk/go 0.3.5 2.210.3 1.0.0 airbyte",
 		},
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
Fixes #64 -- `const` fields that weren't `required` were being omitted: this sends them (and hence fixes trustpilot `credentials.auth_type`)