### PR TITLE
changed primary key to non-computed

### DIFF
--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -98,7 +98,7 @@ func (r *ConnectionResource) Schema(ctx context.Context, req resource.SchemaRequ
 									},
 								},
 								"primary_key": schema.ListAttribute{
-									Computed: true,
+									Computed: false,
 									PlanModifiers: []planmodifier.List{
 										speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
 									},


### PR DESCRIPTION
This PR obviously changes the code generated by Speakeasy, so someone will have to modify the speakeasy config correctly to make this change.  However, this fixes #91   

Recreating the issue:
Create a postgres source that reads from a table that has a defined primary key and use `"sync_mode": "incremental_deduped_history"` - do not supply a primary key here.  This should be able to be applied.  However, if you make an changes to this resource, terraform will read and try to send the primary key that was supplied by the database causing the API error `primary key for stream: <stream> already pre-defined. Please do NOT include a
primary key configuration for this stream` and will not be able to apply the change.  

By changing `primary_key` in `streams` to non-computed, we avoid this error.