### PR TITLE
docs(snowflake): fix description of snowflake warehouse

### DIFF
--- a/airbyte.yaml
+++ b/airbyte.yaml
@@ -68460,7 +68460,7 @@ components:
           order: 1
         warehouse:
           description: "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\"\
-            >warehouse</a> that you want to sync data into"
+            >warehouse</a> that you want to use as a compute cluster"
           examples:
           - "AIRBYTE_WAREHOUSE"
           type: "string"
@@ -68650,7 +68650,7 @@ components:
           order: 1
         warehouse:
           description: "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\"\
-            >warehouse</a> that you want to sync data into"
+            >warehouse</a> that you want to use as a compute cluster"
           examples:
           - "AIRBYTE_WAREHOUSE"
           type: "string"

--- a/docs/resources/destination_snowflake.md
+++ b/docs/resources/destination_snowflake.md
@@ -66,7 +66,7 @@ Required:
 - `role` (String) Enter the <a href="https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles">role</a> that you want to use to access Snowflake
 - `schema` (String) Enter the name of the default <a href="https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl">schema</a>
 - `username` (String) Enter the name of the user you want to use to access the database
-- `warehouse` (String) Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to sync data into
+- `warehouse` (String) Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to use as a compute cluster
 
 Optional:
 

--- a/docs/resources/destination_snowflake_cortex.md
+++ b/docs/resources/destination_snowflake_cortex.md
@@ -169,7 +169,7 @@ Required:
 - `host` (String) Enter the account name you want to use to access the database. This is usually the identifier before .snowflakecomputing.com
 - `role` (String) Enter the role that you want to use to access Snowflake
 - `username` (String) Enter the name of the user you want to use to access the database
-- `warehouse` (String) Enter the name of the warehouse that you want to sync data into
+- `warehouse` (String) Enter the name of the warehouse that you want to use as a compute cluster
 
 <a id="nestedatt--configuration--indexing--credentials"></a>
 ### Nested Schema for `configuration.indexing.credentials`

--- a/internal/provider/destination_snowflake_resource.go
+++ b/internal/provider/destination_snowflake_resource.go
@@ -177,7 +177,7 @@ func (r *DestinationSnowflakeResource) Schema(ctx context.Context, req resource.
 					},
 					"warehouse": schema.StringAttribute{
 						Required:    true,
-						Description: `Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to sync data into`,
+						Description: `Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to use as a compute cluster`,
 					},
 				},
 			},

--- a/internal/provider/destination_snowflakecortex_resource.go
+++ b/internal/provider/destination_snowflakecortex_resource.go
@@ -218,7 +218,7 @@ func (r *DestinationSnowflakeCortexResource) Schema(ctx context.Context, req res
 							},
 							"warehouse": schema.StringAttribute{
 								Required:    true,
-								Description: `Enter the name of the warehouse that you want to sync data into`,
+								Description: `Enter the name of the warehouse that you want to use as a compute cluster`,
 							},
 						},
 						Description: `Snowflake can be used to store vector data and retrieve embeddings.`,

--- a/internal/sdk/models/shared/destinationsnowflake.go
+++ b/internal/sdk/models/shared/destinationsnowflake.go
@@ -327,7 +327,7 @@ type DestinationSnowflake struct {
 	Schema string `json:"schema"`
 	// Enter the name of the user you want to use to access the database
 	Username string `json:"username"`
-	// Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to sync data into
+	// Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to use as a compute cluster
 	Warehouse string `json:"warehouse"`
 }
 

--- a/internal/sdk/models/shared/destinationsnowflakecortex.go
+++ b/internal/sdk/models/shared/destinationsnowflakecortex.go
@@ -480,7 +480,7 @@ type DestinationSnowflakeCortexSnowflakeConnection struct {
 	Role string `json:"role"`
 	// Enter the name of the user you want to use to access the database
 	Username string `json:"username"`
-	// Enter the name of the warehouse that you want to sync data into
+	// Enter the name of the warehouse that you want to use as a compute cluster
 	Warehouse string `json:"warehouse"`
 }
 

--- a/internal/sdk/models/shared/destinationsnowflakecortexupdate.go
+++ b/internal/sdk/models/shared/destinationsnowflakecortexupdate.go
@@ -457,7 +457,7 @@ type SnowflakeConnection struct {
 	Role string `json:"role"`
 	// Enter the name of the user you want to use to access the database
 	Username string `json:"username"`
-	// Enter the name of the warehouse that you want to sync data into
+	// Enter the name of the warehouse that you want to use as a compute cluster
 	Warehouse string `json:"warehouse"`
 }
 

--- a/internal/sdk/models/shared/destinationsnowflakeupdate.go
+++ b/internal/sdk/models/shared/destinationsnowflakeupdate.go
@@ -303,7 +303,7 @@ type DestinationSnowflakeUpdate struct {
 	Schema string `json:"schema"`
 	// Enter the name of the user you want to use to access the database
 	Username string `json:"username"`
-	// Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to sync data into
+	// Enter the name of the <a href="https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses">warehouse</a> that you want to use as a compute cluster
 	Warehouse string `json:"warehouse"`
 }
 


### PR DESCRIPTION
In Snowflake, warehouse is a computer cluster instead of a place to save data. Yeah, I know the term is misleading.

Here are docs:

- https://docs.snowflake.com/en/user-guide/warehouses
- https://www.reddit.com/r/snowflake/comments/16758sn/trivia_why_did_snowflake_choose_name_warehouse/

I opened another related pull request at  https://github.com/airbytehq/airbyte/pull/40717
