### PR TITLE
fix: #113 update applications/token URL

### DIFF
--- a/airbyte.yaml
+++ b/airbyte.yaml
@@ -86889,7 +86889,7 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: /api/v1/applications/token
+          tokenUrl: applications/token
           scopes: {}
 security:
   - bearerAuth: []


### PR DESCRIPTION
This PR fix #113 when using the provider with client_id and client_secret for getting an access_token

Fix the tokenURL endpoint string for the API

PS: I don't know how to force the speakeasy generation or if it's automatically done during the release ?