### PR TITLE
chore: Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: all docs
-all: speakeasy docs
+all: speakeasy
 
 speakeasy:
-	speakeasy generate sdk --lang terraform -o . -s airbyte.yaml
+	speakeasy run
 
 docs:
+	go mod download
 	go generate ./...
 


### PR DESCRIPTION
This change accomplishes the following in the `Makefile`:

* Switches the `speakeasy` target `speakeasy` CLI command from `generate sdk` to `run`. This is recommended to ensure all generation features run as expected, such as Terraform provider code compilation.
* Removes the `docs` target from the default target. The compilation that occurs during `speakeasy run` will automatically handle documentation regeneration.
* Leaves the `docs` target, but with an added `go mod download` command to prevent Go errors in case anyone wants to make purely Terraform provider documentation changes outside what Speakeasy generates.