### PR TITLE
docs: use real provider version inside example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "0.13.0"
+      version = "0.6.5"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "0.13.0"
+      version = "0.6.5"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "0.13.0"
+      version = "0.6.5"
     }
   }
 }


### PR DESCRIPTION
When I check docs

https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs

I thought 0.13.0 is latest version. But when I apply, it says this version does not exist. Then I found 0.6.5 is actually latest version.

Ideally it will always use latest version here. I am not sure how.
So just change the version in the example to use a real version. ☺️