### PR TITLE
ci: Double linter timeout to 2 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 #v6.1.0
         with:
           version: latest
+          args: --timeout 2m
 
   generate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflows for linting have been failing due to hitting their timeouts. This PR doubles the timeout to 2 minutes.

(I don't know your conventional commit format but I gave it an educated guess)