### PR TITLE
ci: disable cron schedule for speakeasy generation

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -11,8 +11,6 @@ permissions:
                 description: Force generation of SDKs
                 type: boolean
                 default: false
-    schedule:
-        - cron: 0 0 * * *
 jobs:
     generate:
         uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15


### PR DESCRIPTION
The speakeasy generation workflow doesn't currently work, so let's disable it. 