### PR TITLE
chore: Add workflow to auto-label community PRs from forks

### DIFF
--- a/.github/workflows/label-community-prs.yml
+++ b/.github/workflows/label-community-prs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Add community label
         # This action uses GitHub's addLabels API, which is idempotent.
         # If the label already exists, the API call succeeds without error.
-        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.3
+        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: community


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically applies the `community` label to PRs opened from forks. This enables automatic tracking on the [Community PRs project board](https://github.com/orgs/airbytehq/projects/148).

The workflow:
- Triggers on `pull_request_target` events (`opened` and `reopened`)
- Only runs for PRs from forks (via `if: github.event.pull_request.head.repo.fork == true`)
- Uses the [`actions-ecosystem/action-add-labels`](https://github.com/actions-ecosystem/action-add-labels) marketplace action (v1.1.0, pinned by SHA)
- The action's `addLabels` API is idempotent—if the label already exists, it succeeds without error

## Review & Testing Checklist for Human

- [ ] Verify the workflow does NOT checkout or execute any code from the fork (security requirement for `pull_request_target`)
- [ ] Confirm the `community` label exists in this repository
- [ ] Verify the pinned action SHA (`bd52874380e3909a1ac983768df6976535ece7f8`) matches [v1.1.0](https://github.com/actions-ecosystem/action-add-labels/releases/tag/v1.1.0)

**Test plan:** After merging, open a PR from a fork (or close/reopen an existing fork PR) to verify the label is applied automatically.

### Notes

This workflow cannot be tested via CI since it only triggers on actual fork PRs.

**Updates since initial revision:**
- Fixed version comment from v1.1.3 to v1.1.0 (the SHA was always correct, just the comment was wrong)
- Added required `github_token` input to the action

**Requested by:** @aaronsteers (AJ Steers)
**Devin session:** https://app.devin.ai/sessions/b0784474061f4084a04ce5251ce1e9f2