### PR TITLE
ci: Add custom CodeQL workflow to fix disk space issues

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: "CodeQL config"
+
+# Exclude generated code from analysis to reduce disk usage and analysis time.
+# The Speakeasy-generated SDK and per-connector provider files are large and
+# not hand-written, so excluding them focuses CodeQL on meaningful code.
+paths-ignore:
+  - internal/sdk/**
+  - internal/provider/destination_*.go
+  - internal/provider/source_*.go
+  - internal/provider/types/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "25 2 * * 1" # weekly on Monday
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Go mod download
+        run: go mod download
+
+      # Manual build instead of CodeQL autobuild to avoid disk space issues
+      - name: Build
+        run: go build -v .
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"


### PR DESCRIPTION
## Summary

Adds a custom CodeQL workflow to replace GitHub's default setup, which has been failing with "No space left on device" errors for weeks across all runs (main, PRs, and scheduled).

**Root cause**: The default CodeQL autobuild exhausts the GitHub Actions runner's disk space when analyzing the large Speakeasy-generated codebase (~66MB of generated Go code).

**Fix approach**:
- Use manual build (`go build -v .`) instead of autobuild
- Exclude generated code directories via `paths-ignore` config
- Add 60-minute timeout to prevent runaway jobs

## Review & Testing Checklist for Human

- [ ] **Disable default CodeQL setup** in repo settings after merge - otherwise both the old failing workflow and this new one will run in parallel
- [ ] Verify the `paths-ignore` patterns correctly match generated files (destination_*.go, source_*.go, internal/sdk/**, internal/provider/types/**)
- [ ] Confirm excluding generated code from security analysis is acceptable (generated code is not hand-written and is the primary cause of disk exhaustion)
- [ ] After merge, monitor the first CodeQL run to verify it completes successfully

**Test plan**: After merging, check the next scheduled CodeQL run (Monday 2:25 AM UTC) or push to main to trigger a run. Verify it completes without disk space errors.

### Notes

- The workflow runs on push to main, PRs targeting main, and weekly on Mondays
- This PR was requested by @aaronsteers
- Devin session: https://app.devin.ai/sessions/d4040e7fe05e4ce495c498b73dea1713