### PR TITLE
ci: add /generate slash command for SDK generation workflow

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -29,6 +29,14 @@ permissions:
                 description: Force generation of SDKs
                 type: boolean
                 default: false
+            pr:
+                description: 'PR number'
+                type: string
+                required: false
+            comment-id:
+                description: 'Comment ID (for slash command triggers)'
+                type: string
+                required: false
 env:
     GO_VERSION: "1.24"
 jobs:
@@ -36,6 +44,29 @@ jobs:
         name: Generate SDK
         runs-on: ubuntu-latest
         steps:
+            - name: Authenticate as GitHub App
+              if: github.event.inputs.pr
+              uses: actions/create-github-app-token@v2
+              id: get-app-token
+              with:
+                  app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+                  private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+            - name: Post or append starting comment
+              if: github.event.inputs.pr
+              id: start-comment
+              uses: peter-evans/create-or-update-comment@v5
+              with:
+                  token: ${{ steps.get-app-token.outputs.token }}
+                  issue-number: ${{ github.event.inputs.pr }}
+                  comment-id: ${{ github.event.inputs.comment-id || '' }}
+                  body: |
+                      > **Generate SDK Job Info**
+                      >
+                      > Running Speakeasy SDK generation (force=${{ github.event.inputs.force || 'false' }}).
+
+                      > Job started... [Check job output.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
@@ -85,3 +116,23 @@ jobs:
                   branch: speakeasy-sdk-regen
                   base: main
                   delete-branch: true
+
+            - name: Append success comment
+              if: success() && github.event.inputs.pr
+              uses: peter-evans/create-or-update-comment@v5
+              with:
+                  token: ${{ steps.get-app-token.outputs.token }}
+                  comment-id: ${{ steps.start-comment.outputs.comment-id }}
+                  reactions: hooray
+                  body: |
+                      > SDK generation completed successfully.
+
+            - name: Append failure comment
+              if: failure() && github.event.inputs.pr
+              uses: peter-evans/create-or-update-comment@v5
+              with:
+                  token: ${{ steps.get-app-token.outputs.token }}
+                  comment-id: ${{ steps.start-comment.outputs.comment-id }}
+                  reactions: confused
+                  body: |
+                      > SDK generation failed. Check the [job output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -33,6 +33,7 @@ jobs:
           issue-type: pull-request
           commands: |
             tf-examples
+            generate
           static-args: |
             pr=${{ github.event.issue.number }}
             comment-id=${{ github.event.comment.id }}


### PR DESCRIPTION
## Summary

Adds `/generate` slash command support to trigger the Speakeasy SDK generation workflow from PR comments. This follows the same pattern established by the `/tf-examples` command.

Changes:
- Renamed `speakeasy_sdk_generation.yml` to `generate-command.yml` (following the `-command.yml` convention)
- Added `pr` and `comment-id` inputs to the workflow for slash command triggers
- Added comment handling: posts job status to the PR when triggered via slash command
- Added `generate` to the slash command dispatch workflow

## Review & Testing Checklist for Human

- [ ] **Verify Octavia bot secrets exist**: The workflow requires `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` secrets (same as `/tf-examples`)
- [ ] **Test slash command after merge**: Comment `/generate` on a PR to verify the workflow triggers and posts comments correctly
- [ ] **Verify manual workflow_dispatch still works**: The workflow should still be triggerable from Actions > Generate > Run workflow

### Notes

The workflow file rename from `speakeasy_sdk_generation.yml` to `generate-command.yml` is intentional to follow the naming convention used by other slash command workflows in this repo.

Requested by: @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/fc0ec95dc1a04e7a870f10698c047cc0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/241">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
