### PR TITLE
chore: Bump version to 1.0.0-rc2

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -26,7 +26,7 @@ generation:
     skipResponseBodyAssertions: false
   telemetryEnabled: true
 terraform:
-  version: 0.19.0
+  version: 1.0.0-rc2
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []


### PR DESCRIPTION
## Summary

Updates the Terraform provider version from `0.19.0` to `1.0.0-rc2` in the Speakeasy configuration file (`gen.yaml`). This overrides the auto-incrementing minor version behavior to set the desired release candidate version.

## Review & Testing Checklist for Human

- [ ] Verify Speakeasy supports the `1.0.0-rc2` pre-release version format
- [ ] After merging, trigger the generation workflow and confirm the generated `docs/index.md` shows `version = "1.0.0-rc2"` in the required_providers block

### Notes

Requested by: @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/9774a96f5bc2486c88702474c106e8c0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
