### PR TITLE
ci: Revert runs-on image to ubuntu-latest for generation dry run

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -56,7 +56,7 @@ name: Generate TF Provider (New PR)
 jobs:
     generate:
         name: Generate SDK
-        runs-on: ubuntu-latest-16core
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         # Note: No explicit permissions here to allow workflow_call from
         # pull_request triggers (which have restricted permissions).


### PR DESCRIPTION
## Summary

Reverts the GitHub Actions runner from `ubuntu-latest-16core` to the default `ubuntu-latest` for the Speakeasy generation workflow.

The 16-core runner was added in PR #246 to speed up generation, but the standard runner should be sufficient for validation purposes.

## Review & Testing Checklist for Human

- [ ] Verify that the 30-minute timeout is sufficient for generation on the standard runner (the 16-core image was added to address potential timeout issues)
- [ ] Monitor the next few dry run executions to ensure they complete successfully

### Notes

- Requested by: @aaronsteers
- Link to Devin run: https://app.devin.ai/sessions/9774a96f5bc2486c88702474c106e8c0