### PR TITLE
fix: Restore version to 1.0.0-rc2 after Speakeasy auto-increment

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -27,7 +27,7 @@ generation:
     skipResponseBodyAssertions: false
   telemetryEnabled: true
 terraform:
-  version: 0.20.1
+  version: 1.0.0-rc2
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []


### PR DESCRIPTION
## Summary

Restores the Terraform provider version to `1.0.0-rc2` in `gen.yaml`. 

PR #255 set the version to `1.0.0-rc2`, but PR #259 (Speakeasy SDK regeneration) auto-incremented it to `0.20.1`, overwriting the intended version bump.

## Review & Testing Checklist for Human

- [ ] After merging, trigger the `/generate` workflow to regenerate the SDK with the correct version - the generated files (README.md, docs/index.md, etc.) still show `0.20.1` and need to be updated

### Notes

This is a minimal fix to restore the version configuration. The Speakeasy workflow auto-increments versions during generation, which is why the manual version bump was overwritten.

Requested by: @aaronsteers

Link to Devin run: https://app.devin.ai/sessions/9774a96f5bc2486c88702474c106e8c0
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/260">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
