### PR TITLE
ci(release): Fix snapshot version to use clean semver without SNAPSHOT suffix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,10 @@
 version: 2
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+snapshot:
+  # Use clean version for snapshot builds (no -SNAPSHOT suffix)
+  # This is needed for release-drafter workflow which builds assets before tagging
+  version_template: '{{ .Version }}'
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
## Summary

Fixes the snapshot version naming in GoReleaser to produce clean semver versions instead of versions with `-SNAPSHOT-{commit}` suffix.

After PR #265 was merged, the release-drafter workflow ran and attached assets to the v1.0.0 draft release. However, the assets were incorrectly named with SNAPSHOT suffix (e.g., `terraform-provider-airbyte_1.0.0-SNAPSHOT-f0a935b1b_linux_amd64.zip`). The Terraform Registry expects clean version names like `terraform-provider-airbyte_1.0.0_linux_amd64.zip`.

This adds a `snapshot.version_template` config to `.goreleaser.yml` that uses `{{ .Version }}` instead of the default `{{ .Version }}-SNAPSHOT-{{.ShortCommit}}`.

## Review & Testing Checklist for Human

- [ ] **Verify template syntax** - Confirm `{{ .Version }}` is the correct GoReleaser template variable (not `{{ .Tag }}` which includes the `v` prefix)
- [ ] **Test the workflow** - After merging, trigger release-drafter via workflow_dispatch and verify assets are named correctly
- [ ] **Check existing draft** - The current v1.0.0 draft has incorrectly named assets; these will need to be replaced by re-running the workflow

**Recommended test plan:**
1. Merge this PR
2. Manually trigger the release-drafter workflow
3. Check the v1.0.0 draft release - assets should be named like `terraform-provider-airbyte_1.0.0_linux_amd64.zip` (no SNAPSHOT)

### Notes

**Requested by:** @aaronsteers
**Link to Devin run:** https://app.devin.ai/sessions/4b423fac72fd4fc7a569eb813b6753c8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/268">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
