### PR TITLE
ci(release): Cancel in-progress release-drafter runs when new commits are pushed

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,7 @@ on:
 
 concurrency:
   group: release-drafter
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Changes the `cancel-in-progress` setting from `false` to `true` in the release-drafter workflow's concurrency configuration. This ensures that when a new commit is pushed to main, any in-progress release-drafter workflow runs are cancelled.

The rationale is that subsequent runs will replace the results of prior runs (updating the draft release with new assets), so there's no benefit to letting the prior run complete.

## Review & Testing Checklist for Human

- [ ] Confirm this behavior is desired - new pushes to main will cancel any in-progress release-drafter runs

### Notes

**Requested by:** @aaronsteers
**Link to Devin run:** https://app.devin.ai/sessions/4b423fac72fd4fc7a569eb813b6753c8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/269">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
