### PR TITLE
ci(speakeasy): Use Octavia-Bot for PR creation and disable auto-merge

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -231,7 +231,7 @@ jobs:
                   base: main
                   delete-branch: true
 
-            # Auto-merge is disabled until we can validate version bumps
+            # Auto-merge is disabled until confidence in the process is higher
             # - name: Enable auto-merge for automated PRs
             #   if: |
             #       (github.event_name == 'push'


### PR DESCRIPTION
## Summary

Updates the Speakeasy SDK generation workflow to:
1. Create PRs as the Octavia-Bot GitHub App instead of `github-actions[bot]`
2. Disable auto-merge until version bump validation is in place

**Context**: The auto-merge was causing issues where invalid version bumps (like 1.0.0 → 1.0.1) were being automatically merged when the release draft state was incorrect. Disabling auto-merge ensures a human reviews version changes before merging.

## Review & Testing Checklist for Human

- [ ] Verify `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` secrets are configured (they should be - already used for PR comments in this workflow)
- [ ] After merge, trigger the generate workflow and confirm the PR is created by Octavia-Bot
- [ ] Confirm auto-merge does NOT happen on push/schedule triggers

### Notes

Requested by: @aaronsteers  
Devin session: https://app.devin.ai/sessions/4b423fac72fd4fc7a569eb813b6753c8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/271">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
