### PR TITLE
fix: Update PUT response templates to return 200 with response body

### DIFF
--- a/scripts/generate_terraform_spec.py
+++ b/scripts/generate_terraform_spec.py
@@ -102,7 +102,11 @@ SOURCE_PATH_TEMPLATE = """\
             schema:
               $ref: "#/components/schemas/Source{upper_camel_name}PutRequest"
       responses:
-        "204":
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SourceResponse"
           description: "The resource was updated successfully"
         "403":
           description: "Not allowed"
@@ -195,7 +199,11 @@ DESTINATION_PATH_TEMPLATE = """\
             schema:
               $ref: "#/components/schemas/Destination{upper_camel_name}PutRequest"
       responses:
-        "204":
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationResponse"
           description: "The resource was updated successfully"
         "403":
           description: "Not allowed"


### PR DESCRIPTION
## Summary

Changes the OpenAPI spec generation templates for typed source/destination PUT operations from expecting `204 No Content` to `200 OK` with a response body schema.

This fixes the `unknown status code returned: Status 200` errors reported in #254 when using typed resources like `airbyte_destination_bigquery`.

**Root cause**: The `SOURCE_PATH_TEMPLATE` and `DESTINATION_PATH_TEMPLATE` in `generate_terraform_spec.py` specified `204` as the success response, but the Airbyte API returns `200` with the updated resource in the response body. This caused Speakeasy to generate SDK code that only handled 204, treating 200 responses as errors.

## Review & Testing Checklist for Human

- [ ] **Verify API behavior**: Confirm the Airbyte API actually returns HTTP 200 (not 204) for PUT operations on sources/destinations. I inferred this from the error output showing a response body, but did not directly test against the API.
- [ ] **Regenerate SDK after merge**: This PR only changes the template. The SDK must be regenerated (`uv run scripts/generate_terraform_spec.py && speakeasy run`) for the fix to take effect.
- [ ] **End-to-end test**: After regeneration, test updating a typed resource (e.g., `airbyte_destination_bigquery`) to verify the 200 response is handled correctly.

### Notes

- The generic `putDestination` function already correctly handles 200 responses - this change aligns the typed resources with that behavior.
- This does NOT fix the separate `v5_page_size` issue in #254, which appears to be a connector version mismatch on the user's Airbyte instance.

---
**Requested by:** @aaronsteers  
**Link to Devin run:** https://app.devin.ai/sessions/0601bc5e518945a8b0bdfce2871f9663
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/276">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
