### PR TITLE
fix: Add /v1 prefix to OAuth2 token endpoint URL

### DIFF
--- a/airbyte.yaml
+++ b/airbyte.yaml
@@ -95092,7 +95092,7 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: /applications/token
+          tokenUrl: /v1/applications/token
           scopes: {}
 security:
   - bearerAuth: []

--- a/internal/sdk/models/shared/schemeclientcredentials.go
+++ b/internal/sdk/models/shared/schemeclientcredentials.go
@@ -9,7 +9,7 @@ import (
 type SchemeClientCredentials struct {
 	ClientID     string `security:"name=clientID"`
 	ClientSecret string `security:"name=clientSecret"`
-	TokenURL     string `default:"/applications/token"`
+	TokenURL     string `default:"/v1/applications/token"`
 }
 
 func (s SchemeClientCredentials) MarshalJSON() ([]byte, error) {

--- a/scripts/generate_terraform_spec.py
+++ b/scripts/generate_terraform_spec.py
@@ -412,7 +412,7 @@ SECURITY_SCHEMES = """  securitySchemes:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: /applications/token
+          tokenUrl: /v1/applications/token
           scopes: {}
 security:
   - bearerAuth: []


### PR DESCRIPTION
## Summary

Fixes https://github.com/airbytehq/terraform-provider-airbyte/issues/280

The default OAuth2 token endpoint was `/applications/token`, which resolved to `https://api.airbyte.com/applications/token` instead of the correct `https://api.airbyte.com/v1/applications/token`. This caused 401 errors for all users authenticating via client credentials.

**Root cause:** Go's `url.ResolveReference()` follows RFC 3986 — a reference starting with `/` is treated as an absolute path, replacing the entire base URL path. So base `https://api.airbyte.com/v1` + `/applications/token` = `https://api.airbyte.com/applications/token`, losing the `/v1` prefix.

**Fix:** Change the default token URL from `/applications/token` to `/v1/applications/token` in all three locations where it's defined:
- `airbyte.yaml` (base OpenAPI spec)
- `scripts/generate_terraform_spec.py` (spec generation template)
- `internal/sdk/models/shared/schemeclientcredentials.go` (generated Go default)

## Review & Testing Checklist for Human

- [ ] **Verify the correct production token endpoint is `/v1/applications/token`** — e.g., confirm via `curl -X POST https://api.airbyte.com/v1/applications/token` with valid credentials
- [ ] **Confirm `internal/sdk/applications.go:585` should NOT be changed** — it uses `url.JoinPath(baseURL, "/applications/token")` which correctly produces `/v1/applications/token` (unlike `ResolveReference`). This is the API resource endpoint, not the OAuth token hook
- [ ] **Test OAuth client credentials auth end-to-end** — configure the provider with `client_id`/`client_secret` (no explicit `token_url`) and run `terraform plan` against a real resource to confirm auth succeeds
- [ ] **Confirm Speakeasy regeneration consistency** — the generated file `schemeclientcredentials.go` was edited directly. Verify that regenerating from the updated `airbyte.yaml` spec produces the same `/v1/applications/token` default

### Notes
- The generated Go file is marked `DO NOT EDIT`, but the corresponding spec sources (`airbyte.yaml`, `generate_terraform_spec.py`) are also updated, so future regeneration should be consistent.
- [Link to Devin run](https://app.devin.ai/sessions/fbf90768d2e143e7a9b4dce944fd4610)
- Requested by @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
