### PR TITLE
ci: Add TK-TODO check workflow

### DIFF
--- a/.github/workflows/tk-todo-check.yml
+++ b/.github/workflows/tk-todo-check.yml
@@ -1,4 +1,4 @@
-name: TK-TODO Check
+name: TK-TODO Check  # IGNORE:TK
 
 on:
   pull_request:
@@ -6,13 +6,13 @@ on:
       - main
 
 jobs:
-  check-tk-todos:
+  check-tk-todos:  # IGNORE:TK
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for TK-TODO markers
-        uses: aaronsteers/tk-todo-check-action@v1
+      - name: Check for TK-TODO markers  # IGNORE:TK
+        uses: aaronsteers/tk-todo-check-action@v1  # IGNORE:TK
         with:
           fail-on-found: "true"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that checks for `TK-TODO` markers in the codebase and fails the CI if any are found. This uses the [`aaronsteers/tk-todo-check-action`](https://github.com/aaronsteers/tk-todo-check-action) reusable action.

The workflow:
- Runs on all PRs targeting `main`
- Fails if any `TK-TODO` markers are found (unless the line also contains `IGNORE:TK`)
- Helps enforce that temporary TODO markers are resolved before merge

## Review & Testing Checklist for Human

- [ ] Verify the `aaronsteers/tk-todo-check-action@v1` tag exists and is the intended version
- [ ] Note: There are existing `TK-TODO` markers in the repo (e.g., in `test-projects/v1-tf-latest-test/main.tf` from PR #279) - these will cause this check to fail on PRs that include those files until resolved

### Notes

- Link to Devin run: https://app.devin.ai/sessions/1ee356b4dc194526a5e6e58ce54492bb
- Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
