### PR TITLE
fix(connection): resolve unknown values for schedule.basic_timing and schedule.cron_expression after apply

### DIFF
--- a/internal/provider/connection_resource_sdk.go
+++ b/internal/provider/connection_resource_sdk.go
@@ -130,11 +130,10 @@ func (r *ConnectionResourceModel) RefreshFromSharedConnectionResponse(ctx contex
 		r.Prefix = types.StringPointerValue(resp.Prefix)
 		if r.Schedule == nil {
 			r.Schedule = &tfTypes.AirbyteAPIConnectionSchedule{}
-
-			r.Schedule.BasicTiming = types.StringPointerValue(resp.Schedule.BasicTiming)
-			r.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)
-			r.Schedule.ScheduleType = types.StringValue(string(resp.Schedule.ScheduleType))
 		}
+		r.Schedule.BasicTiming = types.StringPointerValue(resp.Schedule.BasicTiming)
+		r.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)
+		r.Schedule.ScheduleType = types.StringValue(string(resp.Schedule.ScheduleType))
 		r.SourceID = types.StringValue(resp.SourceID)
 		r.Status = types.StringValue(string(resp.Status))
 		r.StatusReason = types.StringPointerValue(resp.StatusReason)


### PR DESCRIPTION
# fix(connection): resolve unknown schedule values after apply

Closes https://github.com/airbytehq/terraform-provider-airbyte/issues/285

## Summary

When a user provides a `schedule` block on an `airbyte_connection` resource (e.g. `schedule_type = "manual"`), the `RefreshFromSharedConnectionResponse` method skipped populating the computed sub-fields (`basic_timing`, `cron_expression`, `schedule_type`) because `r.Schedule` was already non-nil from the Terraform plan. Since `basic_timing` is `Computed`-only, it stayed in an "unknown" state, triggering Terraform's *"Provider returned invalid result object after apply"* error.

The fix moves the three field assignments **outside** the `if r.Schedule == nil` guard so they are always populated from the API response.

## Review & Testing Checklist for Human

- [ ] **Verify `resp.Schedule` is never nil in API responses.** If the Airbyte API can return a connection without a `schedule` object, the moved lines would panic on `resp.Schedule.BasicTiming`. Check the API spec / real responses for confirmation.
- [ ] **Confirm overwriting `ScheduleType` from the API response doesn't cause plan drift.** The user's planned `schedule_type` value is now always replaced by the API response value—verify these always match.
- [ ] **Test end-to-end with `schedule_type = "manual"` and `schedule_type = "cron"`.** Apply the provider locally and confirm neither case produces "unknown value" errors.

### Notes
- This file is auto-generated (`Code generated by Speakeasy. DO NOT EDIT.`), so this fix will be overwritten on the next `speakeasy run`. A corresponding change to the generation templates or spec may be needed for a permanent fix.
- [Link to Devin run](https://app.devin.ai/sessions/55b4ee3b6dff41609629cccee5f00573)
- Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
