### PR TITLE
feat: add MoveState support for typed-to-generic resource migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ provider_installation {
 ```
 <!-- End Testing the provider locally [usage] -->
 
+## Migrating from Typed to Generic Resources
+
+If you are using typed resources (e.g., `airbyte_source_pardot`) and need to migrate to the generic `airbyte_source` or `airbyte_destination` resource, see the [Migration Guide](docs/MIGRATION_GUIDE.md).
+
 <!-- Start Authentication [security] -->
 ## Authentication
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -119,11 +119,11 @@ resource "airbyte_destination" "my_dest" {
 }
 ```
 
-## Alternative methods (Terraform < 1.7) {#alternative-methods-terraform-17}
+## Alternative methods (Terraform < 1.8) {#alternative-methods-terraform-17}
 
-If you cannot use Terraform 1.8+, you can migrate using the `removed` and `import` blocks (Terraform 1.7+) or CLI commands.
+If you cannot use Terraform 1.8+, you can migrate using either `removed` + `import` blocks (Terraform 1.7.x) or CLI commands (any Terraform version).
 
-### Option A: `removed` + `import` blocks (Terraform 1.7+)
+### Option A: `removed` + `import` blocks (Terraform 1.7.x)
 
 ```hcl
 removed {

--- a/internal/provider/destination_resource_movestate.go
+++ b/internal/provider/destination_resource_movestate.go
@@ -46,10 +46,10 @@ func (r *DestinationResource) MoveState(ctx context.Context) []resource.StateMov
 
 				targetState := DestinationResourceModel{
 					DestinationID:   types.StringValue(destinationID),
-					Name:            types.StringValue(extractJSONString(rawState, "name")),
-					WorkspaceID:     types.StringValue(extractJSONString(rawState, "workspace_id")),
-					DefinitionID:    types.StringValue(extractJSONString(rawState, "definition_id")),
-					DestinationType: types.StringValue(extractJSONString(rawState, "destination_type")),
+					Name:            extractJSONTypesString(rawState, "name"),
+					WorkspaceID:     extractJSONTypesString(rawState, "workspace_id"),
+					DefinitionID:    extractJSONTypesString(rawState, "definition_id"),
+					DestinationType: extractJSONTypesString(rawState, "destination_type"),
 					CreatedAt:       extractJSONInt64(rawState, "created_at"),
 					Configuration:   &tfTypes.DestinationConfiguration{},
 				}

--- a/internal/provider/movestate_helpers.go
+++ b/internal/provider/movestate_helpers.go
@@ -19,6 +19,21 @@ func extractJSONString(raw map[string]json.RawMessage, key string) string {
 	return s
 }
 
+func extractJSONTypesString(raw map[string]json.RawMessage, key string) types.String {
+	v, ok := raw[key]
+	if !ok {
+		return types.StringNull()
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return types.StringNull()
+	}
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
 func extractJSONInt64(raw map[string]json.RawMessage, key string) types.Int64 {
 	v, ok := raw[key]
 	if !ok {

--- a/internal/provider/source_resource_movestate.go
+++ b/internal/provider/source_resource_movestate.go
@@ -46,16 +46,13 @@ func (r *SourceResource) MoveState(ctx context.Context) []resource.StateMover {
 
 				targetState := SourceResourceModel{
 					SourceID:      types.StringValue(sourceID),
-					Name:          types.StringValue(extractJSONString(rawState, "name")),
-					WorkspaceID:   types.StringValue(extractJSONString(rawState, "workspace_id")),
-					DefinitionID:  types.StringValue(extractJSONString(rawState, "definition_id")),
-					SourceType:    types.StringValue(extractJSONString(rawState, "source_type")),
+					Name:          extractJSONTypesString(rawState, "name"),
+					WorkspaceID:   extractJSONTypesString(rawState, "workspace_id"),
+					DefinitionID:  extractJSONTypesString(rawState, "definition_id"),
+					SourceType:    extractJSONTypesString(rawState, "source_type"),
+					SecretID:      extractJSONTypesString(rawState, "secret_id"),
 					CreatedAt:     extractJSONInt64(rawState, "created_at"),
 					Configuration: &tfTypes.SourceConfiguration{},
-				}
-
-				if secretID := extractJSONString(rawState, "secret_id"); secretID != "" {
-					targetState.SecretID = types.StringValue(secretID)
 				}
 
 				resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetState)...)


### PR DESCRIPTION
## Summary

Implements `ResourceWithMoveState` on `SourceResource` and `DestinationResource` to let users migrate from typed resources (e.g., `airbyte_source_pardot`) to the generic `airbyte_source`/`airbyte_destination` resources using Terraform's `moved` block (requires Terraform 1.8+).

This enables a safe, declarative migration path when a connector's upstream config schema changes and the typed resource no longer validates. Instead of destroy+recreate (which would delete the Airbyte source/destination), users write a one-line `moved` block and Terraform handles the state migration.

**New files:**
- `source_resource_movestate.go` / `destination_resource_movestate.go` — `MoveState` handlers that match any `airbyte_source_*` / `airbyte_destination_*` typed resource, extract the resource ID and common fields from raw JSON state, and populate the generic resource's state model.
- `movestate_helpers.go` — JSON extraction utilities: `extractJSONString` (returns raw string), `extractJSONTypesString` (returns `types.StringNull()` for missing/invalid fields), and `extractJSONInt64`.
- `docs/MIGRATION_GUIDE.md` — User-facing migration guide with examples for `moved` block (TF 1.8+), `removed`+`import` blocks (TF 1.7.x), and CLI fallback.

**How it works:** A single handler per resource type uses prefix matching (`airbyte_source_*`) to cover all 584+ typed source resources and 85+ destination resources automatically. It extracts common top-level fields from the raw state JSON (`source_id`, `name`, `workspace_id`, `definition_id`, etc.) and sets the generic resource's `Configuration` to an empty struct—relying on Terraform's subsequent `Read` call to hydrate the full configuration from the Airbyte API.

### Updates since last revision

- **Null-safe field extraction**: Added `extractJSONTypesString()` helper that returns `types.StringNull()` when a field is missing, fails to unmarshal, or is empty. All optional fields in both handlers now use this instead of `types.StringValue(extractJSONString(...))`, which previously stored missing fields as known empty strings and could cause plan diffs. Only `source_id` / `destination_id` remain as hard-error requirements.
- **Consistent `secret_id` handling**: Source handler now uses `extractJSONTypesString` for `secret_id` like all other optional fields (no special-case conditional).
- **Migration guide fixes**: Section title corrected from "Terraform < 1.7" to "Terraform < 1.8"; sub-sections clarified for 1.7.x vs. any version.
- **README.md link**: Added a "Migrating from Typed to Generic Resources" section to README.md linking to the migration guide, placed outside auto-generated `<!-- Start/End -->` blocks.
- **Moved migration guide** from `docs/guides/migrating-to-generic-resources.md` to `docs/MIGRATION_GUIDE.md`. The `docs/guides/` subdirectory was being deleted by `go generate` (`tfplugindocs`).

## Review & Testing Checklist for Human

- [ ] **Verify the MoveState → Read lifecycle**: `Configuration` is set to `&SourceConfiguration{}` (empty struct) during state move. Confirm that Terraform's `Read` call after `moved` fully hydrates configuration from the API and doesn't produce unexpected plan diffs. This is the highest-risk area—if Read doesn't overwrite configuration, users could see drift or errors.
- [ ] **Verify `resource_allocation` omission is safe**: The `resource_allocation` field (a complex nested struct) is NOT carried over from the old state—it will be `nil`. Confirm that Read populates it, or that a nil value doesn't cause plan failures.
- [ ] **Validate the Pardot `definition_id` in docs**: The migration guide uses `5e6175e5-68e1-4c17-bff9-56103bbb0d80` as the Pardot definition ID. Verify this is correct.
- [ ] **Consider adding unit tests**: There are no tests for the MoveState handlers. Consider whether this should block merge or be a fast-follow.

**Recommended test plan:**
1. Create a typed source (e.g., `airbyte_source_faker`) with `terraform apply`
2. Add a `moved` block pointing to `airbyte_source` and update the resource definition
3. Run `terraform plan` — should show "moved" not "destroy/create"
4. Run `terraform apply` — should succeed without API calls to delete/create
5. Run `terraform plan` again — should show no changes (confirms Read hydrated state correctly)

### Notes

- Requires Terraform 1.8+ for the `moved` block approach. Docs include fallback methods for older versions.
- These are hand-written files added alongside generated code. If Speakeasy regenerates and changes `SourceResourceModel`/`DestinationResourceModel` field names, these files will fail to compile (which is the desired failure mode—loud, not silent).
- The README.md link is placed outside auto-generated blocks but the file is still managed by Speakeasy—may need monitoring.

Link to Devin run: https://app.devin.ai/sessions/3aedbd114e6e4f338dbe830c2bb916d6
Requested by: @aaronsteers