### PR TITLE
ci: bump semantic-pr-release-drafter to v1.1.0

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -134,7 +134,7 @@ jobs:
 
             - name: Get next version from release drafter
               id: get-version
-              uses: aaronsteers/semantic-pr-release-drafter@v0.7.0
+              uses: aaronsteers/semantic-pr-release-drafter@v1.1.0
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       # Step 1: Create/update draft release (no assets yet)
       - name: Create draft release
-        uses: aaronsteers/semantic-pr-release-drafter@v1.0.0
+        uses: aaronsteers/semantic-pr-release-drafter@v1.1.0
         id: release-drafter
         with:
           name-template: 'v$RESOLVED_VERSION'


### PR DESCRIPTION
## Summary

Bumps `aaronsteers/semantic-pr-release-drafter` to `v1.1.0` in both workflow files that use it:

| Workflow | Previous Version | New Version |
|----------|-----------------|-------------|
| `generate-command.yml` | `v0.7.0` | `v1.1.0` |
| `release-drafter.yml` | `v1.0.0` | `v1.1.0` |

## Review & Testing Checklist for Human

- [ ] **Verify `resolved-version` output compatibility**: Both workflows depend on `steps.get-version.outputs.resolved-version` / `steps.release-drafter.outputs.resolved-version`. Confirm that v1.1.0 still produces this output — especially for `generate-command.yml` which is jumping from v0.7.0 (a major version gap).
- [ ] **Verify `with:` inputs in `release-drafter.yml`**: The release drafter step passes `name-template`, `tag-template`, `change-template`, and `template` inputs. Confirm these are still supported in v1.1.0.
- [ ] **Test on next merge to main**: These workflows trigger on push to main, so CI on this PR won't exercise the actual action. After merge, monitor the next "Release Drafter" and "Generate TF Provider" runs to confirm they succeed.

### Notes

- CI on this PR cannot validate the action version change since these workflows are triggered by push-to-main / schedule, not by PR checks.

Link to Devin run: https://app.devin.ai/sessions/3aedbd114e6e4f338dbe830c2bb916d6
Requested by: @aaronsteers