### PR TITLE
ci: add concurrency group to cancel stale generation runs

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -67,6 +67,11 @@ name: Generate TF Provider (New PR)
                 description: Validate generation without creating a PR
                 type: boolean
                 default: false
+concurrency:
+    # Push/schedule runs share a group so newer runs cancel stale ones.
+    # Other triggers (workflow_dispatch, workflow_call) get unique groups to avoid cancelling each other.
+    group: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && 'generate-new-pr' || format('generate-{0}', github.run_id) }}
+    cancel-in-progress: true
 jobs:
     generate:
         name: Generate SDK


### PR DESCRIPTION
# ci: add concurrency group to cancel stale generation runs

## Summary

Adds a `concurrency` block to the "Generate TF Provider (New PR)" workflow so that when multiple pushes to main stack up, newer runs cancel older in-progress ones instead of all running to completion redundantly.

The concurrency group uses a conditional expression:
- **`push` / `schedule`** triggers share a fixed group (`generate-new-pr`) → newer runs cancel stale ones
- **`workflow_dispatch` / `workflow_call`** triggers each get a unique group (keyed on `run_id`) → they never cancel each other

## Review & Testing Checklist for Human

- [ ] **Verify the ternary expression evaluates correctly for all four trigger types** — the expression `(event == 'push' || event == 'schedule') && 'generate-new-pr' || format('generate-{0}', run_id)` relies on GitHub Actions' JS-style short-circuit evaluation. Confirm `workflow_call` produces `github.event_name == 'workflow_call'` (not the caller's event name) so it gets its own unique group
- [ ] **Confirm push-cancels-schedule is acceptable** — a push and a scheduled run share the same group, so a push will cancel a running scheduled generation. This seems correct (push has newer code) but worth a conscious decision
- [ ] **Test after merge** — trigger two rapid pushes to main and verify the first run gets cancelled. CI cannot exercise this logic

### Notes
- This is untestable by CI — the concurrency behavior can only be observed in real workflow runs after merge.

Link to Devin run: https://app.devin.ai/sessions/ae1ba17982e94d4f9d632dfe2f620bc6
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
