### PR TITLE
ci: only enable auto-merge when creating a new PR, not on updates

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -266,11 +266,11 @@ jobs:
                   base: main
                   delete-branch: true
 
-            - name: Enable auto-merge (fully automated PR)
+            - name: Enable auto-merge (new PR only)
               if: |
                   (github.event_name == 'push'
                    || github.event_name == 'schedule'
-                  ) && steps.create-pr.outputs.pull-request-number
+                  ) && steps.create-pr.outputs.pull-request-operation == 'created'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash


### PR DESCRIPTION
# ci: only enable auto-merge for newly created Speakeasy PRs

## Summary

Gates the auto-merge step on `pull-request-operation == 'created'` instead of just checking for a PR number. This way, when the generation workflow pushes updates to an existing `speakeasy-sdk-regen` PR, it preserves whatever auto-merge state a human has set (e.g., if someone manually disabled auto-merge, the next update won't re-enable it).

Previously, the condition `steps.create-pr.outputs.pull-request-number` was truthy for both new and updated PRs, so every generation run would re-enable auto-merge.

## Review & Testing Checklist for Human

- [ ] **Verify `pull-request-operation` output exists in `peter-evans/create-pull-request@v6`** — the [action docs](https://github.com/peter-evans/create-pull-request#outputs) confirm it outputs `created`, `updated`, or `closed`, but worth a sanity check since a typo here would silently prevent auto-merge from ever triggering
- [ ] **Test end-to-end after merge**: trigger two consecutive generation runs — the first should create a PR with auto-merge enabled, the second should update it without changing the auto-merge state

### Notes
- Worst-case failure mode is benign: if the output name/value is wrong, auto-merge simply never enables and a human merges manually.

Link to Devin run: https://app.devin.ai/sessions/ae1ba17982e94d4f9d632dfe2f620bc6
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
