### PR TITLE
fix(security): mark `airbyte_secret` fields as sensitive for Terraform

### DIFF
--- a/scripts/generate_terraform_spec.py
+++ b/scripts/generate_terraform_spec.py
@@ -492,13 +492,6 @@ def transform_connector_spec(
     return schema_name, transformed
 
 
-def _add_sensitive_marker(transformed: dict[str, Any]) -> dict[str, Any]:
-    """Add x-speakeasy-param-sensitive when airbyte_secret is true."""
-    if transformed.get("airbyte_secret") is True:
-        transformed["x-speakeasy-param-sensitive"] = True
-    return transformed
-
-
 def _strip_hidden_defaults(transformed: dict[str, Any]) -> dict[str, Any]:
     """Strip default values from airbyte_hidden fields so they aren't forced in API requests."""
     if transformed.get("airbyte_hidden") is True and "default" in transformed:
@@ -529,17 +522,17 @@ def transform_spec_properties(spec: dict[str, Any], is_update: bool) -> dict[str
             for prop_name, prop_value in value.items():
                 if isinstance(prop_value, dict):
                     transformed = transform_spec_properties(prop_value, is_update)
-                    result[key][prop_name] = _add_sensitive_marker(_strip_hidden_defaults(transformed))
+                    result[key][prop_name] = _strip_hidden_defaults(transformed)
                 else:
                     result[key][prop_name] = prop_value
         elif key == "oneOf" or key == "anyOf" or key == "allOf":
             result[key] = [
-                _add_sensitive_marker(_strip_hidden_defaults(transform_spec_properties(item, is_update)))
+                _strip_hidden_defaults(transform_spec_properties(item, is_update))
                 if isinstance(item, dict) else item
                 for item in value
             ]
         elif isinstance(value, dict):
-            result[key] = _add_sensitive_marker(_strip_hidden_defaults(transform_spec_properties(value, is_update)))
+            result[key] = _strip_hidden_defaults(transform_spec_properties(value, is_update))
         else:
             result[key] = value
 


### PR DESCRIPTION
## Summary

Adds a single Speakeasy overlay rule that targets all connector spec properties with `airbyte_secret: true` and adds `x-speakeasy-param-sensitive: true`, so Speakeasy generates `Sensitive: true` in the Terraform provider schema. This prevents secrets (API keys, passwords, tokens) from appearing in `terraform plan` output and CI/CD logs.

**This is a regression fix.** Pre-1.0 versions (e.g. v0.13.0) correctly had `Sensitive: true` on secret fields like Stripe's `client_secret`. This was lost during the 1.0 regeneration because the new pipeline uses `airbyte_secret: true` from the connector registry, and nothing was converting that to Speakeasy's `x-speakeasy-param-sensitive: true`.

The fix is a single JSONPath wildcard rule in `overlays/terraform_speakeasy.yaml`:
```yaml
- target: "$.components.schemas..properties.*[?(@.airbyte_secret == true)]"
  update:
    x-speakeasy-param-sensitive: true
```

**Local validation:** Running `speakeasy overlay apply` against the generated spec confirmed the rule matches **2,313 fields** across all connector schemas (matching the count of `airbyte_secret: true` occurrences).

Closes https://github.com/airbytehq/terraform-provider-airbyte/issues/234

## Review & Testing Checklist for Human

- [ ] **Run the full generation pipeline** (`generate_terraform_spec.py` → `speakeasy run`) and verify that a typed connector with known secrets (e.g. Stripe's `client_secret`) now has `Sensitive: true` in the generated Go resource file. The overlay was validated with `speakeasy overlay apply` but full codegen was not run locally (Speakeasy auth was unavailable). The existing `x-speakeasy-param-sensitive` annotations in `airbyte.yaml` do produce `Sensitive: true` in the current Go code, so this is expected to work — but should be confirmed.
- [ ] **Spot-check edge cases in nested schemas** — the JSONPath uses recursive descent (`..properties.*`), which should reach fields inside `oneOf`/`anyOf` variants. Verify a connector with nested auth options (e.g. a source with OAuth + API key variants) has sensitive marking at all nesting levels.
- [ ] **Verify `terraform plan` UX is acceptable** — ~2,300 fields will now show `(sensitive value)` instead of the actual value, which changes the debugging experience. Confirm this trade-off is acceptable.

### Notes

- The generic `airbyte_source` / `airbyte_destination` resources are still registered in the provider (not removed in rc5). Their `configuration` attribute remains un-sensitive. This PR only addresses typed connector resources.
- Link to Devin run: https://app.devin.ai/sessions/5ec703b764ca4a4c8cb6ec2677ffaa2e
- Requested by: @aaronsteers