### PR TITLE
ci: fix generation lint errors (SA5008, U1000)

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -166,8 +166,9 @@ jobs:
             - name: Clean generated code
               run: |
                   rm -rf internal/sdk
-                  rm -f internal/provider/destination_*.go
-                  rm -f internal/provider/source_*.go
+                  # Delete generated source/destination files but preserve hand-written ones
+                  find internal/provider/ -name 'destination_*.go' ! -name '*movestate*' ! -name '*helpers*' -delete
+                  find internal/provider/ -name 'source_*.go' ! -name '*movestate*' ! -name '*helpers*' -delete
                   rm -rf internal/provider/types/
 
             - name: Generate Provider ${{ steps.get-version.outputs.resolved-version }} with Speakeasy

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["inherit", "-SA5008"]


### PR DESCRIPTION
## Summary

Fixes two lint errors that cause the "Generate TF Provider" workflow to fail during Speakeasy's internal "Lint SDK" step:

1. **U1000 (unused functions)**: The clean step used `rm -f internal/provider/source_*.go` / `destination_*.go` globs, which accidentally deleted hand-written movestate files (`source_resource_movestate.go`, `destination_resource_movestate.go`). Since Speakeasy doesn't regenerate these, `movestate_helpers.go` functions became orphaned. Fixed by switching to `find` with exclusion patterns for `*movestate*` and `*helpers*` files.

2. **SA5008 (unexported struct field with json tag)**: Speakeasy generates unexported struct fields with json tags for discriminator constants (`sourceType`, `mode`, `auth_type`, etc.) — ~2,320 instances. Added a root-level `staticcheck.conf` to suppress this check.

## Review & Testing Checklist for Human

- [ ] **Verify `staticcheck.conf` is respected by Speakeasy's internal lint step.** This is the biggest uncertainty — Speakeasy runs `staticcheck` as part of `speakeasy run`, and it's unclear whether it picks up project-level config files. If not, SA5008 errors will persist and a different approach is needed.
- [ ] **Check that `find` exclusion patterns won't accidentally preserve generated files.** The patterns `! -name '*movestate*'` and `! -name '*helpers*'` are broad. Confirm Speakeasy doesn't generate files matching these patterns.
- [ ] **Trigger a generation run on this branch** (via workflow dispatch or `/generate` slash command) to validate end-to-end that the "Lint SDK" step passes.

### Notes
- The U1000 errors have been present since the movestate files were added (~Feb 10). The SA5008 errors appear to be newer, possibly from a Speakeasy CLI version change (workflow uses `speakeasyVersion: latest`).
- [Link to Devin run](https://app.devin.ai/sessions/5ec703b764ca4a4c8cb6ec2677ffaa2e)
- Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
