### PR TITLE
fix(ci): change versioningStrategy from automatic to manual

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -20,7 +20,7 @@ generation:
   schemas:
     allOfMergeStrategy: shallowMerge
   requestBodyFieldName: ""
-  versioningStrategy: automatic
+  versioningStrategy: manual
   persistentEdits: {}
   tests:
     generateTests: true


### PR DESCRIPTION
# fix(ci): change versioningStrategy from automatic to manual

## Summary

One-line config change in `gen.yaml`: switches Speakeasy's `versioningStrategy` from `automatic` to `manual`.

With `automatic`, Speakeasy auto-increments the pre-release version on every regeneration (e.g., `1.0.0-rc6` → `1.0.0-rc6.1`) based on config checksum or generator version changes — even when `--set-version` is explicitly passed from release drafter. This conflicts with our release drafter-controlled versioning. Per [Speakeasy docs](https://www.speakeasy.com/docs/speakeasy-reference/generation/gen-yaml#versioningstrategy), `manual` means the version is used as-is without automatic bumping, which is what we want since the workflow already passes `--set-version=$VERSION`.

Observed in [PR #314](https://github.com/airbytehq/terraform-provider-airbyte/pull/314) where the version was bumped from `1.0.0-rc6` to `1.0.0-rc6.1` despite release drafter targeting `1.0.0-rc6`.

## Review & Testing Checklist for Human

- [ ] **Verify `manual` + `--set-version` interaction**: Confirm from [Speakeasy docs](https://www.speakeasy.com/docs/speakeasy-reference/generation/gen-yaml#versioningstrategy) that `manual` mode still respects `--set-version` passed via CLI (vs. only reading from gen.yaml). This was not tested locally due to lack of Speakeasy API key.
- [ ] **Trigger a regeneration after merge** and confirm the version in gen.yaml/gen.lock matches what release drafter provides (no auto-bump).

### Notes
- Requested by @aaronsteers
- [Link to Devin run](https://app.devin.ai/sessions/7a0244b98409499ba5d105d35138f0c8)
- This also relates to the Speakeasy nil safety fix (1.716.2+) — the regeneration triggered in this session ([PR #312](https://github.com/airbytehq/terraform-provider-airbyte/pull/312)) successfully upgraded Speakeasy from 1.716.1 → 1.717.0 and confirmed the build passes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
