### PR TITLE
ci: move paths-ignore to job-level skip for required check compatibility

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           filters: |
             generation:
+              - '**'
               - '!README.md'
               - '!docs/**'
               - '!examples/**'


### PR DESCRIPTION
## Summary

Fixes a bug where the required check "Validate Generation (Dry Run) / Generate SDK" blocks docs-only PRs (like regeneration PR #321 which only changes `docs/**`).

**Root cause:** GitHub Actions' workflow-level `paths-ignore` causes the workflow to never run, leaving the required check as "Expected — Waiting for status to be reported" (permanently pending). In contrast, a job-level skip reports the check as "skipped", which GitHub treats as equivalent to "passed" for required checks.

**Change:** Removes `paths-ignore` from the workflow trigger and adds a `check-paths` job using `dorny/paths-filter@v3` to determine if non-docs files changed. The `validate` job is conditionally skipped at the job level when only docs/README/examples change.

## Review & Testing Checklist for Human

- [ ] **Verify `dorny/paths-filter` negation syntax is correct.** The filter uses `!`-prefixed patterns (`'!docs/**'`, etc.) — confirm this means "output is true when any changed file does NOT match these patterns" (i.e., true when non-docs files change). If the logic is inverted, either all PRs or no PRs will run the expensive generation.
- [ ] **Verify the required check name is reported correctly when skipped.** When `validate` is skipped via `if: false`, GitHub needs to report "Validate Generation (Dry Run) / Generate SDK" as "skipped" — not omit it entirely. Since `validate` calls a reusable workflow, confirm that the nested job name still appears in the status checks when the calling job is skipped. **This is the highest-risk item** — if GitHub doesn't report the nested check name, this fix won't work.
- [ ] **Test on a docs-only PR** (like #321) to confirm the required check is satisfied and the PR can merge.

### Notes
- Requested by @aaronsteers
- [Devin session](https://app.devin.ai/sessions/7a0244b98409499ba5d105d35138f0c8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
