### PR TITLE
fix: omit empty slices/maps with omitempty in custom MarshalJSON

### DIFF
--- a/internal/sdk/internal/utils/json.go
+++ b/internal/sdk/internal/utils/json.go
@@ -72,6 +72,10 @@ func MarshalJSON(v interface{}, tag reflect.StructTag, topLevel bool) ([]byte, e
 					continue
 				}
 
+				if omitEmpty && isEmptyContainer(field.Type, fieldVal) {
+					continue
+				}
+
 				if omitZero && fieldVal.IsZero() {
 					continue
 				}


### PR DESCRIPTION
## Summary

Fixes [#332](https://github.com/airbytehq/terraform-provider-airbyte/issues/332). The Speakeasy-generated custom `MarshalJSON` in `json.go` only checked `isNil()` for `omitempty` fields, which returns `false` for empty non-nil slices (`[]T{}`). This caused the provider to send `"selectedFields":[]` in API requests instead of omitting the field entirely, triggering API 400 errors: *"No fields selected for stream"*.

The fix adds the existing `isEmptyContainer()` helper to the `omitempty` code path, aligning behavior with Go's standard `encoding/json` which omits empty slices, arrays, and maps.

**Reproduction path:** Provider state refresh initializes `SelectedFields` as `[]SelectedFieldInfo{}` → request builder creates `make([]SelectedFieldInfo, 0, 0)` → custom MarshalJSON serializes as `"selectedFields":[]` → API rejects.

## Review & Testing Checklist for Human

- [ ] **Broad serialization impact**: This changes `omitempty` behavior for ALL fields across the entire SDK, not just `selectedFields`. Verify no other API calls depend on sending empty arrays `[]` or empty maps `{}` to the Airbyte API. Grep for `omitempty` usage in `shared/` models and consider which fields could be affected.
- [ ] **Permanence plan**: This edits a Speakeasy-generated file (`// Code generated by Speakeasy ... DO NOT EDIT`). The fix will be overwritten on next `speakeasy run`. Decide whether to: (a) add a post-generation patch step, (b) report upstream to Speakeasy, or (c) accept re-applying on regen.
- [ ] **End-to-end verification**: Test with a real connection that has streams with no explicit field selection. Run `terraform plan`/`terraform apply` and confirm no 400 error. Ideally also verify the JSON payload no longer contains `"selectedFields":[]` (e.g., enable debug logging or use a proxy).

### Notes
- The `isEmptyContainer()` function already existed in `utils.go` but was unused in the `omitempty` path — this was effectively a Speakeasy codegen bug.
- All existing unit tests pass. No test specifically covers this empty-slice-omitempty interaction.
- Link to Devin run: https://app.devin.ai/sessions/b3cef8dd31724e0d805f2be3b9f13ece
- Requested by: @aaronsteers