### PR TITLE
docs: add semantic-pr-release-drafter link to Releasing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,9 +246,11 @@ This avoids maintaining the same content in two places and ensures Terraform use
 
 ## Releasing
 
-This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. For the general release workflow, see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).
+This project uses [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) for automated release management. To release, simply click "`Edit`" on the latest release draft from the [releases page](https://github.com/airbytehq/terraform-provider-airbyte/releases), and then click "`Publish release`". This publish operation will trigger all necessary downstream publish operations.
 
-After each merge to main, a draft release is created/updated automatically. You can click "Edit" and the "Publish release" button to finalize it. Once published, the release is synced to the Terraform Registry within minutes.
+ℹ️ For more detailed instructions, please see the [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md).
+
+After each merge to main, a draft release is created/updated automatically. Once published, the release is synced to the Terraform Registry within minutes.
 
 Terraform receives webhook notifications from GitHub, see below.
 


### PR DESCRIPTION
# docs: add semantic-pr-release-drafter link to Releasing section

## Summary

Updates the "Releasing" section in CONTRIBUTING.md to reference [`semantic-pr-release-drafter`](https://github.com/aaronsteers/semantic-pr-release-drafter) and its shared [Releasing Guide](https://github.com/aaronsteers/semantic-pr-release-drafter/blob/main/docs/releasing.md). The existing repo-specific content (Terraform Registry sync, webhook setup, pre-release instructions) is fully preserved.

This is part of a cross-repo effort to ensure all repos using `semantic-pr-release-drafter` link to a single source of truth for release instructions, rather than duplicating them. The releasing guide itself is being added in [aaronsteers/semantic-pr-release-drafter#41](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41).

### Updates since last revision

- Replaced the original opening sentence with inline release instructions and a direct link to the [releases page](https://github.com/airbytehq/terraform-provider-airbyte/releases)
- Added ℹ️ callout linking to the detailed Releasing Guide
- The original "After each merge to main…" sentence is preserved but trimmed slightly to avoid duplicating the "click Edit / Publish" instructions now covered above it

## Review & Testing Checklist for Human

- [ ] Verify the trimmed "After each merge to main…" paragraph doesn't lose important context compared to the original. The "click Edit and Publish release" steps were moved into the new paragraph above — confirm this reads well and nothing is lost.
- [ ] Verify that the companion PR ([aaronsteers/semantic-pr-release-drafter#41](https://github.com/aaronsteers/semantic-pr-release-drafter/pull/41)) is merged before or alongside this one, otherwise the Releasing Guide link will 404.
- [ ] Confirm the [releases page link](https://github.com/airbytehq/terraform-provider-airbyte/releases) points to the correct repo.

### Notes

The "Validate Generation (Dry Run) / Generate SDK" CI failure is unrelated to this docs-only change.

Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/d59fa353515f488ab1818b8888d0c3bf)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
