### PR TITLE
docs: streamline v1 migration guide overview

### DIFF
--- a/docs/guides/v1_migration_guide.md
+++ b/docs/guides/v1_migration_guide.md
@@ -7,8 +7,6 @@ Version 1.0 of the Airbyte Terraform provider introduces **generic connector res
 > **Deprecation Notice**
 > Typed connector-specific resources are **officially deprecated** as of 1.0. They remain available in 1.0 for backward compatibility but are **targeted for removal in 1.1**. Migrate to the generic resources at your earliest convenience.
 
-The generic resources accept freeform JSON configuration via `jsonencode()`, which means they are immune to upstream schema changes that previously caused `422 Unprocessable Entity` errors with typed resources.
-
 The recommended way to use the generic resources is with the [`airbyte_connector_configuration`](../data-sources/connector_configuration.md) data source, which provides:
 - Automatic `definition_id` resolution from connector name
 - Optional version pinning via `connector_version` (e.g. `"3.6.28"`)

--- a/templates/guides/v1_migration_guide.md.tmpl
+++ b/templates/guides/v1_migration_guide.md.tmpl
@@ -7,8 +7,6 @@ Version 1.0 of the Airbyte Terraform provider introduces **generic connector res
 > **Deprecation Notice**
 > Typed connector-specific resources are **officially deprecated** as of 1.0. They remain available in 1.0 for backward compatibility but are **targeted for removal in 1.1**. Migrate to the generic resources at your earliest convenience.
 
-The generic resources accept freeform JSON configuration via `jsonencode()`, which means they are immune to upstream schema changes that previously caused `422 Unprocessable Entity` errors with typed resources.
-
 The recommended way to use the generic resources is with the [`airbyte_connector_configuration`](../data-sources/connector_configuration.md) data source, which provides:
 - Automatic `definition_id` resolution from connector name
 - Optional version pinning via `connector_version` (e.g. `"3.6.28"`)


### PR DESCRIPTION
## Summary

Removes a sentence from the v1 migration guide overview that was flagged as TMI. The deleted sentence explained that generic resources use `jsonencode()` and are immune to `422 Unprocessable Entity` errors from upstream schema changes — an implementation detail that isn't necessary for users reading the migration guide.

The change was made in the template (`templates/guides/v1_migration_guide.md.tmpl`) and regenerated into `docs/guides/v1_migration_guide.md` via `poe docs-generate`.

## Review & Testing Checklist for Human

- [ ] Read the migration guide overview (lines 5–16 of the template) to confirm the flow from the deprecation notice into the `airbyte_connector_configuration` recommendation still reads naturally without the removed sentence

### Notes

Requested by: @aaronsteers
[Devin session](https://app.devin.ai/sessions/0c90ebea722c4d7ab082953e2c2ec8ea)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
