### PR TITLE
fix: initialize Notifications pointer in workspace SDK to prevent nil dereference

### DIFF
--- a/internal/provider/workspace_data_source_sdk.go
+++ b/internal/provider/workspace_data_source_sdk.go
@@ -4,6 +4,7 @@ package provider
 
 import (
 	"context"
+	tfTypes "github.com/airbytehq/terraform-provider-airbyte/internal/provider/types"
 	"github.com/airbytehq/terraform-provider-airbyte/internal/sdk/models/operations"
 	"github.com/airbytehq/terraform-provider-airbyte/internal/sdk/models/shared"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -16,6 +17,7 @@ func (r *WorkspaceDataSourceModel) RefreshFromSharedWorkspaceResponse(ctx contex
 	if resp != nil {
 		r.DataResidency = types.StringValue(resp.DataResidency)
 		r.Name = types.StringValue(resp.Name)
+		r.Notifications = &tfTypes.NotificationsConfig{}
 		if resp.Notifications.ConnectionUpdate == nil {
 			r.Notifications.ConnectionUpdate = nil
 		} else {

--- a/internal/provider/workspace_resource_sdk.go
+++ b/internal/provider/workspace_resource_sdk.go
@@ -4,6 +4,7 @@ package provider
 
 import (
 	"context"
+	tfTypes "github.com/airbytehq/terraform-provider-airbyte/internal/provider/types"
 	"github.com/airbytehq/terraform-provider-airbyte/internal/sdk/models/operations"
 	"github.com/airbytehq/terraform-provider-airbyte/internal/sdk/models/shared"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -16,6 +17,7 @@ func (r *WorkspaceResourceModel) RefreshFromSharedWorkspaceResponse(ctx context.
 	if resp != nil {
 		r.DataResidency = types.StringValue(resp.DataResidency)
 		r.Name = types.StringValue(resp.Name)
+		r.Notifications = &tfTypes.NotificationsConfig{}
 		if resp.Notifications.ConnectionUpdate == nil {
 			r.Notifications.ConnectionUpdate = nil
 		} else {


### PR DESCRIPTION
## Summary

Fixes https://github.com/airbytehq/terraform-provider-airbyte/issues/398

Both `airbyte_workspace` resource and `data.airbyte_workspace` data source crash with a SIGSEGV (nil pointer dereference) during any operation that calls `RefreshFromSharedWorkspaceResponse`.

## Root Cause

The Speakeasy-generated `RefreshFromSharedWorkspaceResponse` in both `workspace_data_source_sdk.go` and `workspace_resource_sdk.go` accesses `r.Notifications.ConnectionUpdate` without first initializing `r.Notifications`, which is a `*tfTypes.NotificationsConfig` pointer (nil by default).

```go
// workspace_data_source_sdk.go (same in workspace_resource_sdk.go)
if resp != nil {
    r.DataResidency = types.StringValue(resp.DataResidency)
    r.Name = types.StringValue(resp.Name)
    if resp.Notifications.ConnectionUpdate == nil {
        r.Notifications.ConnectionUpdate = nil  // PANIC: r.Notifications is nil
```

## Changes

- `workspace_data_source_sdk.go`: Initialize `r.Notifications = &tfTypes.NotificationsConfig{}` before nested field access
- `workspace_resource_sdk.go`: Same fix

## Important: generated code — permanent fix needed upstream

Both modified files are marked `// Code generated by Speakeasy. DO NOT EDIT.` — this PR is a **proof-of-concept** that demonstrates the fix but **will be overwritten on the next Speakeasy regeneration**.

The permanent fix should be applied in the code generation pipeline. Based on the [CONTRIBUTING.md](https://github.com/airbytehq/terraform-provider-airbyte/blob/main/CONTRIBUTING.md), the options are:

1. **Speakeasy overlay** (`terraform_speakeasy.yaml`): Add a post-generation hook or overlay that initializes pointer-typed nested attributes before field access in `Refresh*` functions.
2. **Upstream Speakeasy SDK template**: Report this as a bug to [Speakeasy](https://speakeasy.com) — their Go Terraform code generator should emit nil-guard initialization for pointer-typed nested struct fields in `RefreshFrom*` methods. Any `*tfTypes.SomeStruct` field accessed via `r.Field.SubField` without prior initialization is vulnerable to this class of bug.
3. **Spec transformation** (`generate_terraform_spec.py`): Ensure the `notifications` property in the workspace response schema is not marked as nullable/optional in a way that causes Speakeasy to generate a pointer type without initialization.

We recommend the Airbyte team applies option 1 or 2 so this class of nil pointer dereference is prevented across all resources, not just workspace.

## Testing

Tested against a self-hosted Airbyte OSS instance (v1.1.0 provider, Terraform >= 1.8):
- Before fix: `terraform plan` crashes with SIGSEGV at `workspace_*_sdk.go:25`
- After fix: plan completes successfully, workspace data is read correctly

## Reproduction

Minimal config to reproduce:
```hcl
data "airbyte_workspace" "test" {
  workspace_id = "<any-valid-workspace-id>"
}
```

Or:
```hcl
resource "airbyte_workspace" "test" {
  name = "Test"
}
```

Both crash with:
```
panic: runtime error: invalid memory address or nil pointer dereference
  workspace_resource_sdk.go:25 / workspace_data_source_sdk.go:25
```