### PR TITLE
fix(security): add Sensitive: true to generic source/destination configuration attribute

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,15 +3,15 @@ id: 83e5483d-e9a0-4437-bced-361e3d1a002e
 management:
   docChecksum: 7b3a8c437d8ea05036b502612efb5c69
   docVersion: 1.0.0
-  speakeasyVersion: 1.761.1
-  generationVersion: 2.879.6
+  speakeasyVersion: 1.761.3
+  generationVersion: 2.879.11
   releaseVersion: 1.1.1
   configChecksum: 7dbf16e9a082cfb23a5d440a1b74a3ac
   repoURL: https://github.com/airbytehq/terraform-provider-airbyte.git
 persistentEdits:
-  generation_id: 3dee43a4-0bd1-4b22-8a59-fa7b1067837c
-  pristine_commit_hash: facb76fe02a2a433cc31ffdad9d623a769132f24
-  pristine_tree_hash: 814c754402c331b38aa34eaa29b005d7a71ceec8
+  generation_id: c3d94b2c-f998-40d9-be9f-d2e5ab1bf31b
+  pristine_commit_hash: 2fc68a0d05f80f60ab01c8f093f87bb79f25a3da
+  pristine_tree_hash: 75f694ffc414f7e61eb875e28bd7b728baf256cf
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -1646,8 +1646,8 @@ trackedFiles:
     pristine_git_object: 5b3dc7c122d8ab08905485342d7474f8f163888d
   internal/sdk/sdk.go:
     id: 02d7190ee502
-    last_write_checksum: sha1:f13e0dc507f412cd7eab0349a4ccb6a919e2a630
-    pristine_git_object: 7bccfd4e145f05e491d39e6295846463d8325d11
+    last_write_checksum: sha1:9921c266d2e91e2d2267ca78398460d711f80481
+    pristine_git_object: bf96a3c37aae53f793b30b16921d41c8005ca093
   internal/sdk/sourcedefinitions.go:
     id: 6cda810b4781
     last_write_checksum: sha1:078f7fbb18285e856fbde7c941686d2c8f9cc97f

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.761.1
+speakeasyVersion: 1.761.3
 sources:
     airbyte-api:
         sourceNamespace: my-source

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ uvx --from=poethepoet poe <task-name>
 | `generate-spec` | Generate Terraform OpenAPI spec from upstream API spec | `uv run scripts/generate_terraform_spec.py` |
 | `lint-spec` | Lint the OpenAPI spec for circular references | `speakeasy lint openapi -s generated/api_terraform.yaml` |
 | `generate-code` | Generate Terraform provider code from the OpenAPI spec | `speakeasy run --skip-compile` |
-| `post-generate` | Patch provider registrations and tidy Go modules | `python3 scripts/patch_provider_registrations.py` + `go mod tidy` |
+| `post-generate` | Patch provider registrations, mark configuration as sensitive, and tidy Go modules | `python3 scripts/patch_provider_registrations.py` + `python3 scripts/patch_sensitive_configuration.py` + `go mod tidy` |
 | `docs-generate` | Generate Terraform provider documentation | `go generate ./...` |
 | `bin-generate` | Build cross-platform provider binaries (Linux amd64 + macOS arm64) | `go build -o dist/...` |
 | `generate-full` | Full pipeline: clean, spec, lint, generate, post-generate | Runs the above in sequence |

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -102,7 +102,7 @@ For full details including alternative methods for older Terraform versions, see
 
 ### Required
 
-- `configuration` (String) The values required to configure the destination. The schema for this must match the schema return by destination_definition_specifications/get for the destinationDefinition. Parsed as JSON.
+- `configuration` (String, Sensitive) The values required to configure the destination. The schema for this must match the schema return by destination_definition_specifications/get for the destinationDefinition. Parsed as JSON.
 - `name` (String) Name of the destination e.g. dev-mysql-instance.
 - `workspace_id` (String) Requires replacement if changed.
 

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -97,7 +97,7 @@ For full details including alternative methods for older Terraform versions, see
 
 ### Required
 
-- `configuration` (String) The values required to configure the source. The schema for this must match the schema return by source_definition_specifications/get for the source. Parsed as JSON.
+- `configuration` (String, Sensitive) The values required to configure the source. The schema for this must match the schema return by source_definition_specifications/get for the source. Parsed as JSON.
 - `name` (String) Name of the source e.g. dev-mysql-instance.
 - `workspace_id` (String) Requires replacement if changed.
 

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -62,6 +62,7 @@ func (r *DestinationResource) Schema(ctx context.Context, req resource.SchemaReq
 			"configuration": schema.StringAttribute{
 				CustomType: jsontypes.NormalizedType{},
 				Required:   true,
+				Sensitive:  true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -63,6 +63,7 @@ func (r *SourceResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"configuration": schema.StringAttribute{
 				CustomType: jsontypes.NormalizedType{},
 				Required:   true,
+				Sensitive:  true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.0.0 and generator version 2.879.6
+// Generated from OpenAPI doc version 1.0.0 and generator version 2.879.11
 
 import (
 	"context"
@@ -152,7 +152,7 @@ func New(opts ...SDKOption) *SDK {
 	sdk := &SDK{
 		SDKVersion: "1.1.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.1.1 2.879.6 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.1.1 2.879.11 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -17,7 +17,7 @@ uv run scripts/generate_terraform_spec.py --output generated/api_terraform.yaml
 """
 
 [tasks.post-generate]
-help = "Patch provider registrations, fix workspace nil pointer, and tidy Go modules after Speakeasy generation."
+help = "Patch provider registrations, fix workspace nil pointer, mark configuration as sensitive, and tidy Go modules after Speakeasy generation."
 shell = """
 python3 scripts/patch_provider_registrations.py internal/provider/provider.go
 python3 scripts/patch_workspace_notifications.py

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -21,6 +21,7 @@ help = "Patch provider registrations, fix workspace nil pointer, and tidy Go mod
 shell = """
 python3 scripts/patch_provider_registrations.py internal/provider/provider.go
 python3 scripts/patch_workspace_notifications.py
+python3 scripts/patch_sensitive_configuration.py
 go mod tidy
 """
 

--- a/scripts/patch_sensitive_configuration.py
+++ b/scripts/patch_sensitive_configuration.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Patch source/destination resource schemas to mark configuration as Sensitive.
+
+After Speakeasy regenerates source_resource.go and destination_resource.go,
+the `configuration` attribute is missing `Sensitive: true`. The Speakeasy overlay
+declares `x-speakeasy-param-sensitive: true` on request properties, but Speakeasy
+does not propagate this to the generated Terraform resource schema for attributes
+using `jsontypes.NormalizedType{}`.
+
+This script injects `Sensitive: true` into the `configuration` schema.StringAttribute
+so that Terraform masks the value in plan/apply output and CI/CD logs.
+
+Fixes: https://github.com/airbytehq/terraform-provider-airbyte/issues/408
+Related: https://github.com/airbytehq/terraform-provider-airbyte/issues/234
+
+Usage:
+    python3 scripts/patch_sensitive_configuration.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROVIDER_DIR = Path("internal/provider")
+
+TARGET_FILES = [
+    "source_resource.go",
+    "destination_resource.go",
+]
+
+# The anchor: the line declaring Required: true inside the configuration attribute.
+# We insert Sensitive: true immediately after this line.
+ANCHOR_LINE = "\t\t\t\tRequired:   true,"
+
+# The line to insert after the anchor.
+SENSITIVE_LINE = "\t\t\t\tSensitive:  true,"
+
+# Context marker to ensure we only patch inside the configuration attribute block.
+CONFIG_CONTEXT = '"configuration": schema.StringAttribute{'
+
+
+def patch_file(filepath: Path) -> bool:
+    """Patch a single resource file. Returns True if changes were made."""
+    if not filepath.exists():
+        print(f"ERROR: {filepath} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    content = filepath.read_text()
+
+    # --- Already patched? ---
+    if SENSITIVE_LINE in content:
+        print(f"  Skipping {filepath.name} (already patched)")
+        return False
+
+    # --- Find the configuration attribute block ---
+    config_idx = content.find(CONFIG_CONTEXT)
+    if config_idx == -1:
+        print(
+            f"ERROR: Could not find configuration attribute block in {filepath.name}. "
+            f"Speakeasy output may have changed format.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # --- Find the anchor line within the configuration block ---
+    anchor_idx = content.find(ANCHOR_LINE, config_idx)
+    if anchor_idx == -1:
+        print(
+            f"ERROR: Could not find anchor line (Required: true) in configuration "
+            f"attribute of {filepath.name}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Sanity check: the anchor should be close to the config context (within ~200 chars)
+    if anchor_idx - config_idx > 200:
+        print(
+            f"WARNING: Anchor line is far from configuration block in {filepath.name} "
+            f"(offset {anchor_idx - config_idx}). Proceeding anyway.",
+            file=sys.stderr,
+        )
+
+    # --- Insert Sensitive: true after the anchor ---
+    insert_point = anchor_idx + len(ANCHOR_LINE)
+    content = content[:insert_point] + "\n" + SENSITIVE_LINE + content[insert_point:]
+
+    filepath.write_text(content)
+    print(f"  Added Sensitive: true to {filepath.name}")
+    return True
+
+
+def main() -> None:
+    print("Patching configuration attribute to add Sensitive: true...")
+    any_changed = False
+    for filename in TARGET_FILES:
+        filepath = PROVIDER_DIR / filename
+        if patch_file(filepath):
+            any_changed = True
+
+    if any_changed:
+        print("Done - configuration Sensitive flag applied.")
+    else:
+        print("Done - all files already patched.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch_sensitive_configuration.py
+++ b/scripts/patch_sensitive_configuration.py
@@ -48,38 +48,56 @@ def patch_file(filepath: Path) -> bool:
 
     content = filepath.read_text()
 
-    # --- Already patched? ---
-    if SENSITIVE_LINE in content:
+    # --- Find and validate the configuration attribute block ---
+    config_count = content.count(CONFIG_CONTEXT)
+    if config_count != 1:
+        print(
+            f"ERROR: Expected exactly 1 configuration attribute block in {filepath.name}, "
+            f"found {config_count}. Speakeasy output may have changed format.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    config_idx = content.find(CONFIG_CONTEXT)
+
+    # Find the closing brace of the configuration attribute block.
+    config_end_idx = content.find("\n\t\t\t},", config_idx)
+    if config_end_idx == -1:
+        print(
+            f"ERROR: Could not find the end of the configuration attribute block in "
+            f"{filepath.name}. Speakeasy output may have changed format.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    config_block = content[config_idx:config_end_idx]
+
+    # --- Already patched? (scoped to configuration block) ---
+    if SENSITIVE_LINE in config_block:
         print(f"  Skipping {filepath.name} (already patched)")
         return False
 
-    # --- Find the configuration attribute block ---
-    config_idx = content.find(CONFIG_CONTEXT)
-    if config_idx == -1:
+    # --- Find and validate the anchor line within the configuration block ---
+    anchor_count = config_block.count(ANCHOR_LINE)
+    if anchor_count != 1:
         print(
-            f"ERROR: Could not find configuration attribute block in {filepath.name}. "
-            f"Speakeasy output may have changed format.",
+            f"ERROR: Expected exactly 1 anchor line (Required: true) in configuration "
+            f"attribute of {filepath.name}, found {anchor_count}.",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    # --- Find the anchor line within the configuration block ---
-    anchor_idx = content.find(ANCHOR_LINE, config_idx)
-    if anchor_idx == -1:
-        print(
-            f"ERROR: Could not find anchor line (Required: true) in configuration "
-            f"attribute of {filepath.name}.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    anchor_relative_idx = config_block.find(ANCHOR_LINE)
+    anchor_idx = config_idx + anchor_relative_idx
 
     # Sanity check: the anchor should be close to the config context (within ~200 chars)
-    if anchor_idx - config_idx > 200:
+    if anchor_relative_idx > 200:
         print(
-            f"WARNING: Anchor line is far from configuration block in {filepath.name} "
-            f"(offset {anchor_idx - config_idx}). Proceeding anyway.",
+            f"ERROR: Anchor line is too far from configuration block in {filepath.name} "
+            f"(offset {anchor_relative_idx}). Speakeasy output may have changed format.",
             file=sys.stderr,
         )
+        sys.exit(1)
 
     # --- Insert Sensitive: true after the anchor ---
     insert_point = anchor_idx + len(ANCHOR_LINE)


### PR DESCRIPTION
## Summary

The `configuration` attribute on `airbyte_source` and `airbyte_destination` resources is not marked `Sensitive: true` in the Terraform schema. This means secrets within the configuration JSON blob (API keys, passwords, tokens) are printed in cleartext during `terraform plan`, `terraform apply`, and in CI/CD logs.

The Speakeasy overlay (`overlays/terraform_speakeasy.yaml`) already declares `x-speakeasy-param-sensitive: true` on the relevant request properties, but Speakeasy does not propagate this into the generated Go resource schema for attributes using `jsontypes.NormalizedType{}`.

This PR:
1. Adds `Sensitive: true` to the `configuration` `schema.StringAttribute` in both `source_resource.go` and `destination_resource.go`
2. Adds a new post-generate patch script (`scripts/patch_sensitive_configuration.py`) so the fix survives Speakeasy regeneration
3. Integrates the script into the `post-generate` poe task
4. Updates `poe_tasks.toml` help text and `CONTRIBUTING.md` Poe Tasks table to document the new script

The patch script is idempotent (skips if already patched) and fails loudly if the expected anchors are missing. Safety checks include:
- Validates exactly 1 `"configuration": schema.StringAttribute{` block exists in each file
- Bounds the anchor search to the configuration block's closing `},` (won't match other attributes)
- Validates exactly 1 `Required: true` anchor within the bounded block
- Hard-fails (`sys.exit(1)`) if the anchor is unexpectedly far from the block start

Fixes https://github.com/airbytehq/terraform-provider-airbyte/issues/408

> **Note:** The SDK regeneration commit (Speakeasy 1.761.1 → 1.761.3, generator 2.879.6 → 2.879.11) was triggered via `/generate` to resolve a pre-existing zero-diff CI failure on `internal/sdk/sdk.go`. It is incidental to this PR's changes.

## Review & Testing Checklist for Human

- [ ] **Behavioral change**: After this PR, `terraform plan` and `terraform apply` will show `(sensitive value)` instead of the full configuration JSON for `airbyte_source` and `airbyte_destination` resources. This is intentional but affects all users — **non-sensitive config values are also hidden**. Confirm this trade-off is acceptable.
- [ ] **End-to-end verification**: Run `terraform plan` against a real `airbyte_source` resource with secrets in configuration and confirm the output shows `(sensitive value)` rather than cleartext credentials. The Go build passes, but runtime behavior should be verified.
- [ ] **Patch script anchor robustness**: The script matches exact tab-indented patterns from Speakeasy's Go output. If Speakeasy changes its indentation style, the script will fail loudly (by design). Verify this fail-loud behavior is preferred over a more flexible matching approach.

### Notes

- The root cause (Speakeasy not honoring `x-speakeasy-param-sensitive` for `jsontypes.Normalized` attributes) remains an upstream issue. This patch is a workaround.
- Related to the config preservation work in #396 — that PR changes state from holding redacted `**********` placeholders to real secrets, making this `Sensitive` flag critical before that PR can merge.

Link to Devin session: https://app.devin.ai/sessions/a7af3beb4cd74bd8ad0744e5670bebd3
Requested by: @aaronsteers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/terraform-provider-airbyte/pull/409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
