### PR TITLE
fix(workspace): initialize all nested Notifications pointers to prevent nil dereference

### DIFF
--- a/internal/provider/workspace_data_source_sdk.go
+++ b/internal/provider/workspace_data_source_sdk.go
@@ -21,14 +21,17 @@ func (r *WorkspaceDataSourceModel) RefreshFromSharedWorkspaceResponse(ctx contex
 		if resp.Notifications.ConnectionUpdate == nil {
 			r.Notifications.ConnectionUpdate = nil
 		} else {
+			r.Notifications.ConnectionUpdate = &tfTypes.NotificationConfig{}
 			if resp.Notifications.ConnectionUpdate.Email == nil {
 				r.Notifications.ConnectionUpdate.Email = nil
 			} else {
+				r.Notifications.ConnectionUpdate.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.ConnectionUpdate.Email.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdate.Email.Enabled)
 			}
 			if resp.Notifications.ConnectionUpdate.Webhook == nil {
 				r.Notifications.ConnectionUpdate.Webhook = nil
 			} else {
+				r.Notifications.ConnectionUpdate.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.ConnectionUpdate.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdate.Webhook.Enabled)
 				r.Notifications.ConnectionUpdate.Webhook.URL = types.StringPointerValue(resp.Notifications.ConnectionUpdate.Webhook.URL)
 			}
@@ -36,14 +39,17 @@ func (r *WorkspaceDataSourceModel) RefreshFromSharedWorkspaceResponse(ctx contex
 		if resp.Notifications.ConnectionUpdateActionRequired == nil {
 			r.Notifications.ConnectionUpdateActionRequired = nil
 		} else {
+			r.Notifications.ConnectionUpdateActionRequired = &tfTypes.NotificationConfig{}
 			if resp.Notifications.ConnectionUpdateActionRequired.Email == nil {
 				r.Notifications.ConnectionUpdateActionRequired.Email = nil
 			} else {
+				r.Notifications.ConnectionUpdateActionRequired.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.ConnectionUpdateActionRequired.Email.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdateActionRequired.Email.Enabled)
 			}
 			if resp.Notifications.ConnectionUpdateActionRequired.Webhook == nil {
 				r.Notifications.ConnectionUpdateActionRequired.Webhook = nil
 			} else {
+				r.Notifications.ConnectionUpdateActionRequired.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.ConnectionUpdateActionRequired.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdateActionRequired.Webhook.Enabled)
 				r.Notifications.ConnectionUpdateActionRequired.Webhook.URL = types.StringPointerValue(resp.Notifications.ConnectionUpdateActionRequired.Webhook.URL)
 			}
@@ -51,14 +57,17 @@ func (r *WorkspaceDataSourceModel) RefreshFromSharedWorkspaceResponse(ctx contex
 		if resp.Notifications.Failure == nil {
 			r.Notifications.Failure = nil
 		} else {
+			r.Notifications.Failure = &tfTypes.NotificationConfig{}
 			if resp.Notifications.Failure.Email == nil {
 				r.Notifications.Failure.Email = nil
 			} else {
+				r.Notifications.Failure.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.Failure.Email.Enabled = types.BoolPointerValue(resp.Notifications.Failure.Email.Enabled)
 			}
 			if resp.Notifications.Failure.Webhook == nil {
 				r.Notifications.Failure.Webhook = nil
 			} else {
+				r.Notifications.Failure.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.Failure.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.Failure.Webhook.Enabled)
 				r.Notifications.Failure.Webhook.URL = types.StringPointerValue(resp.Notifications.Failure.Webhook.URL)
 			}
@@ -66,14 +75,17 @@ func (r *WorkspaceDataSourceModel) RefreshFromSharedWorkspaceResponse(ctx contex
 		if resp.Notifications.Success == nil {
 			r.Notifications.Success = nil
 		} else {
+			r.Notifications.Success = &tfTypes.NotificationConfig{}
 			if resp.Notifications.Success.Email == nil {
 				r.Notifications.Success.Email = nil
 			} else {
+				r.Notifications.Success.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.Success.Email.Enabled = types.BoolPointerValue(resp.Notifications.Success.Email.Enabled)
 			}
 			if resp.Notifications.Success.Webhook == nil {
 				r.Notifications.Success.Webhook = nil
 			} else {
+				r.Notifications.Success.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.Success.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.Success.Webhook.Enabled)
 				r.Notifications.Success.Webhook.URL = types.StringPointerValue(resp.Notifications.Success.Webhook.URL)
 			}
@@ -81,14 +93,17 @@ func (r *WorkspaceDataSourceModel) RefreshFromSharedWorkspaceResponse(ctx contex
 		if resp.Notifications.SyncDisabled == nil {
 			r.Notifications.SyncDisabled = nil
 		} else {
+			r.Notifications.SyncDisabled = &tfTypes.NotificationConfig{}
 			if resp.Notifications.SyncDisabled.Email == nil {
 				r.Notifications.SyncDisabled.Email = nil
 			} else {
+				r.Notifications.SyncDisabled.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.SyncDisabled.Email.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabled.Email.Enabled)
 			}
 			if resp.Notifications.SyncDisabled.Webhook == nil {
 				r.Notifications.SyncDisabled.Webhook = nil
 			} else {
+				r.Notifications.SyncDisabled.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.SyncDisabled.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabled.Webhook.Enabled)
 				r.Notifications.SyncDisabled.Webhook.URL = types.StringPointerValue(resp.Notifications.SyncDisabled.Webhook.URL)
 			}
@@ -96,14 +111,17 @@ func (r *WorkspaceDataSourceModel) RefreshFromSharedWorkspaceResponse(ctx contex
 		if resp.Notifications.SyncDisabledWarning == nil {
 			r.Notifications.SyncDisabledWarning = nil
 		} else {
+			r.Notifications.SyncDisabledWarning = &tfTypes.NotificationConfig{}
 			if resp.Notifications.SyncDisabledWarning.Email == nil {
 				r.Notifications.SyncDisabledWarning.Email = nil
 			} else {
+				r.Notifications.SyncDisabledWarning.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.SyncDisabledWarning.Email.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabledWarning.Email.Enabled)
 			}
 			if resp.Notifications.SyncDisabledWarning.Webhook == nil {
 				r.Notifications.SyncDisabledWarning.Webhook = nil
 			} else {
+				r.Notifications.SyncDisabledWarning.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.SyncDisabledWarning.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabledWarning.Webhook.Enabled)
 				r.Notifications.SyncDisabledWarning.Webhook.URL = types.StringPointerValue(resp.Notifications.SyncDisabledWarning.Webhook.URL)
 			}

--- a/internal/provider/workspace_notifications_test.go
+++ b/internal/provider/workspace_notifications_test.go
@@ -1,0 +1,192 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/airbytehq/terraform-provider-airbyte/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// boolPtr is a test helper that returns a pointer to a bool.
+func boolPtr(v bool) *bool { return &v }
+
+// stringPtr is a test helper that returns a pointer to a string.
+func stringPtr(v string) *string { return &v }
+
+func TestWorkspaceResource_RefreshFromSharedWorkspaceResponse_NotificationsNilDeref(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		resp *shared.WorkspaceResponse
+	}{
+		{
+			// Scenario: all notification sub-types are nil.
+			// This is the simplest case — only the top-level pointer matters.
+			name: "all notification sub-types nil — no panic",
+			resp: &shared.WorkspaceResponse{
+				WorkspaceID:   "ws-001",
+				Name:          "test-workspace",
+				DataResidency: "auto",
+				Notifications: shared.NotificationsConfig{},
+			},
+		},
+		{
+			// Scenario: all notification sub-types are non-nil with Email enabled.
+			// Before the fix, this would SIGSEGV on the first sub-type's else branch.
+			name: "all sub-types with email enabled — no panic",
+			resp: &shared.WorkspaceResponse{
+				WorkspaceID:   "ws-002",
+				Name:          "full-notifications",
+				DataResidency: "us",
+				Notifications: shared.NotificationsConfig{
+					ConnectionUpdate:               &shared.NotificationConfig{Email: &shared.EmailNotificationConfig{Enabled: boolPtr(true)}},
+					ConnectionUpdateActionRequired: &shared.NotificationConfig{Email: &shared.EmailNotificationConfig{Enabled: boolPtr(true)}},
+					Failure:                        &shared.NotificationConfig{Email: &shared.EmailNotificationConfig{Enabled: boolPtr(false)}},
+					Success:                        &shared.NotificationConfig{Email: &shared.EmailNotificationConfig{Enabled: boolPtr(true)}},
+					SyncDisabled:                   &shared.NotificationConfig{Email: &shared.EmailNotificationConfig{Enabled: boolPtr(true)}},
+					SyncDisabledWarning:            &shared.NotificationConfig{Email: &shared.EmailNotificationConfig{Enabled: boolPtr(false)}},
+				},
+			},
+		},
+		{
+			// Scenario: all sub-types have both email and webhook configured.
+			// Tests the deepest level of pointer initialization.
+			name: "all sub-types with email and webhook — no panic",
+			resp: &shared.WorkspaceResponse{
+				WorkspaceID:   "ws-003",
+				Name:          "full-email-webhook",
+				DataResidency: "eu",
+				Notifications: shared.NotificationsConfig{
+					ConnectionUpdate: &shared.NotificationConfig{
+						Email:   &shared.EmailNotificationConfig{Enabled: boolPtr(true)},
+						Webhook: &shared.WebhookNotificationConfig{Enabled: boolPtr(true), URL: stringPtr("https://example.com/hook")},
+					},
+					Failure: &shared.NotificationConfig{
+						Email:   &shared.EmailNotificationConfig{Enabled: boolPtr(true)},
+						Webhook: &shared.WebhookNotificationConfig{Enabled: boolPtr(false), URL: stringPtr("https://example.com/fail")},
+					},
+					Success: &shared.NotificationConfig{
+						Email:   &shared.EmailNotificationConfig{Enabled: boolPtr(false)},
+						Webhook: &shared.WebhookNotificationConfig{Enabled: boolPtr(true), URL: stringPtr("https://example.com/success")},
+					},
+					SyncDisabled: &shared.NotificationConfig{
+						Webhook: &shared.WebhookNotificationConfig{Enabled: boolPtr(true), URL: stringPtr("https://example.com/disabled")},
+					},
+					SyncDisabledWarning: &shared.NotificationConfig{
+						Email: &shared.EmailNotificationConfig{Enabled: boolPtr(true)},
+					},
+					ConnectionUpdateActionRequired: &shared.NotificationConfig{
+						Email:   &shared.EmailNotificationConfig{Enabled: boolPtr(true)},
+						Webhook: &shared.WebhookNotificationConfig{Enabled: boolPtr(true), URL: stringPtr("https://example.com/action")},
+					},
+				},
+			},
+		},
+		{
+			// Scenario: sub-types present but Email/Webhook are nil within them.
+			// The else branch for the sub-type fires, but inner nil checks take the nil path.
+			name: "sub-types present with nil Email and Webhook — no panic",
+			resp: &shared.WorkspaceResponse{
+				WorkspaceID:   "ws-004",
+				Name:          "empty-sub-types",
+				DataResidency: "auto",
+				Notifications: shared.NotificationsConfig{
+					ConnectionUpdate:               &shared.NotificationConfig{},
+					ConnectionUpdateActionRequired: &shared.NotificationConfig{},
+					Failure:                        &shared.NotificationConfig{},
+					Success:                        &shared.NotificationConfig{},
+					SyncDisabled:                   &shared.NotificationConfig{},
+					SyncDisabledWarning:            &shared.NotificationConfig{},
+				},
+			},
+		},
+		{
+			// Scenario: mixed — some sub-types nil, some with email only, some with webhook only.
+			name: "mixed nil and non-nil sub-types — no panic",
+			resp: &shared.WorkspaceResponse{
+				WorkspaceID:   "ws-005",
+				Name:          "mixed-notifications",
+				DataResidency: "auto",
+				Notifications: shared.NotificationsConfig{
+					ConnectionUpdate: &shared.NotificationConfig{
+						Email: &shared.EmailNotificationConfig{Enabled: boolPtr(true)},
+					},
+					Failure: nil,
+					Success: &shared.NotificationConfig{
+						Webhook: &shared.WebhookNotificationConfig{Enabled: boolPtr(true), URL: stringPtr("https://example.com/success")},
+					},
+					SyncDisabled: nil,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test WorkspaceResourceModel
+			resource := &WorkspaceResourceModel{}
+			diags := resource.RefreshFromSharedWorkspaceResponse(context.Background(), tc.resp)
+			require.False(t, diags.HasError(), "resource: unexpected error: %s", diags.Errors())
+			assert.Equal(t, tc.resp.Name, resource.Name.ValueString())
+			assert.Equal(t, tc.resp.WorkspaceID, resource.WorkspaceID.ValueString())
+			assert.NotNil(t, resource.Notifications, "resource: Notifications should be initialized")
+
+			// Test WorkspaceDataSourceModel
+			dataSource := &WorkspaceDataSourceModel{}
+			diags = dataSource.RefreshFromSharedWorkspaceResponse(context.Background(), tc.resp)
+			require.False(t, diags.HasError(), "data source: unexpected error: %s", diags.Errors())
+			assert.Equal(t, tc.resp.Name, dataSource.Name.ValueString())
+			assert.Equal(t, tc.resp.WorkspaceID, dataSource.WorkspaceID.ValueString())
+			assert.NotNil(t, dataSource.Notifications, "data source: Notifications should be initialized")
+		})
+	}
+}
+
+func TestWorkspaceResource_RefreshFromSharedWorkspaceResponse_ValuesPreserved(t *testing.T) {
+	t.Parallel()
+
+	// Verify that the patched code correctly populates notification values
+	// from a fully-populated API response.
+	resp := &shared.WorkspaceResponse{
+		WorkspaceID:   "ws-values",
+		Name:          "values-test",
+		DataResidency: "us",
+		Notifications: shared.NotificationsConfig{
+			Failure: &shared.NotificationConfig{
+				Email:   &shared.EmailNotificationConfig{Enabled: boolPtr(true)},
+				Webhook: &shared.WebhookNotificationConfig{Enabled: boolPtr(false), URL: stringPtr("https://hooks.example.com/fail")},
+			},
+			Success: &shared.NotificationConfig{
+				Email: &shared.EmailNotificationConfig{Enabled: boolPtr(false)},
+			},
+		},
+	}
+
+	resource := &WorkspaceResourceModel{}
+	diags := resource.RefreshFromSharedWorkspaceResponse(context.Background(), resp)
+	require.False(t, diags.HasError())
+
+	// Failure sub-type
+	require.NotNil(t, resource.Notifications.Failure)
+	require.NotNil(t, resource.Notifications.Failure.Email)
+	assert.Equal(t, types.BoolValue(true), resource.Notifications.Failure.Email.Enabled)
+	require.NotNil(t, resource.Notifications.Failure.Webhook)
+	assert.Equal(t, types.BoolValue(false), resource.Notifications.Failure.Webhook.Enabled)
+	assert.Equal(t, types.StringValue("https://hooks.example.com/fail"), resource.Notifications.Failure.Webhook.URL)
+
+	// Success sub-type — email only, webhook nil
+	require.NotNil(t, resource.Notifications.Success)
+	require.NotNil(t, resource.Notifications.Success.Email)
+	assert.Equal(t, types.BoolValue(false), resource.Notifications.Success.Email.Enabled)
+	assert.Nil(t, resource.Notifications.Success.Webhook)
+
+	// ConnectionUpdate — nil in response
+	assert.Nil(t, resource.Notifications.ConnectionUpdate)
+}

--- a/internal/provider/workspace_resource_sdk.go
+++ b/internal/provider/workspace_resource_sdk.go
@@ -21,14 +21,17 @@ func (r *WorkspaceResourceModel) RefreshFromSharedWorkspaceResponse(ctx context.
 		if resp.Notifications.ConnectionUpdate == nil {
 			r.Notifications.ConnectionUpdate = nil
 		} else {
+			r.Notifications.ConnectionUpdate = &tfTypes.NotificationConfig{}
 			if resp.Notifications.ConnectionUpdate.Email == nil {
 				r.Notifications.ConnectionUpdate.Email = nil
 			} else {
+				r.Notifications.ConnectionUpdate.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.ConnectionUpdate.Email.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdate.Email.Enabled)
 			}
 			if resp.Notifications.ConnectionUpdate.Webhook == nil {
 				r.Notifications.ConnectionUpdate.Webhook = nil
 			} else {
+				r.Notifications.ConnectionUpdate.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.ConnectionUpdate.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdate.Webhook.Enabled)
 				r.Notifications.ConnectionUpdate.Webhook.URL = types.StringPointerValue(resp.Notifications.ConnectionUpdate.Webhook.URL)
 			}
@@ -36,14 +39,17 @@ func (r *WorkspaceResourceModel) RefreshFromSharedWorkspaceResponse(ctx context.
 		if resp.Notifications.ConnectionUpdateActionRequired == nil {
 			r.Notifications.ConnectionUpdateActionRequired = nil
 		} else {
+			r.Notifications.ConnectionUpdateActionRequired = &tfTypes.NotificationConfig{}
 			if resp.Notifications.ConnectionUpdateActionRequired.Email == nil {
 				r.Notifications.ConnectionUpdateActionRequired.Email = nil
 			} else {
+				r.Notifications.ConnectionUpdateActionRequired.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.ConnectionUpdateActionRequired.Email.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdateActionRequired.Email.Enabled)
 			}
 			if resp.Notifications.ConnectionUpdateActionRequired.Webhook == nil {
 				r.Notifications.ConnectionUpdateActionRequired.Webhook = nil
 			} else {
+				r.Notifications.ConnectionUpdateActionRequired.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.ConnectionUpdateActionRequired.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.ConnectionUpdateActionRequired.Webhook.Enabled)
 				r.Notifications.ConnectionUpdateActionRequired.Webhook.URL = types.StringPointerValue(resp.Notifications.ConnectionUpdateActionRequired.Webhook.URL)
 			}
@@ -51,14 +57,17 @@ func (r *WorkspaceResourceModel) RefreshFromSharedWorkspaceResponse(ctx context.
 		if resp.Notifications.Failure == nil {
 			r.Notifications.Failure = nil
 		} else {
+			r.Notifications.Failure = &tfTypes.NotificationConfig{}
 			if resp.Notifications.Failure.Email == nil {
 				r.Notifications.Failure.Email = nil
 			} else {
+				r.Notifications.Failure.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.Failure.Email.Enabled = types.BoolPointerValue(resp.Notifications.Failure.Email.Enabled)
 			}
 			if resp.Notifications.Failure.Webhook == nil {
 				r.Notifications.Failure.Webhook = nil
 			} else {
+				r.Notifications.Failure.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.Failure.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.Failure.Webhook.Enabled)
 				r.Notifications.Failure.Webhook.URL = types.StringPointerValue(resp.Notifications.Failure.Webhook.URL)
 			}
@@ -66,14 +75,17 @@ func (r *WorkspaceResourceModel) RefreshFromSharedWorkspaceResponse(ctx context.
 		if resp.Notifications.Success == nil {
 			r.Notifications.Success = nil
 		} else {
+			r.Notifications.Success = &tfTypes.NotificationConfig{}
 			if resp.Notifications.Success.Email == nil {
 				r.Notifications.Success.Email = nil
 			} else {
+				r.Notifications.Success.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.Success.Email.Enabled = types.BoolPointerValue(resp.Notifications.Success.Email.Enabled)
 			}
 			if resp.Notifications.Success.Webhook == nil {
 				r.Notifications.Success.Webhook = nil
 			} else {
+				r.Notifications.Success.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.Success.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.Success.Webhook.Enabled)
 				r.Notifications.Success.Webhook.URL = types.StringPointerValue(resp.Notifications.Success.Webhook.URL)
 			}
@@ -81,14 +93,17 @@ func (r *WorkspaceResourceModel) RefreshFromSharedWorkspaceResponse(ctx context.
 		if resp.Notifications.SyncDisabled == nil {
 			r.Notifications.SyncDisabled = nil
 		} else {
+			r.Notifications.SyncDisabled = &tfTypes.NotificationConfig{}
 			if resp.Notifications.SyncDisabled.Email == nil {
 				r.Notifications.SyncDisabled.Email = nil
 			} else {
+				r.Notifications.SyncDisabled.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.SyncDisabled.Email.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabled.Email.Enabled)
 			}
 			if resp.Notifications.SyncDisabled.Webhook == nil {
 				r.Notifications.SyncDisabled.Webhook = nil
 			} else {
+				r.Notifications.SyncDisabled.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.SyncDisabled.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabled.Webhook.Enabled)
 				r.Notifications.SyncDisabled.Webhook.URL = types.StringPointerValue(resp.Notifications.SyncDisabled.Webhook.URL)
 			}
@@ -96,14 +111,17 @@ func (r *WorkspaceResourceModel) RefreshFromSharedWorkspaceResponse(ctx context.
 		if resp.Notifications.SyncDisabledWarning == nil {
 			r.Notifications.SyncDisabledWarning = nil
 		} else {
+			r.Notifications.SyncDisabledWarning = &tfTypes.NotificationConfig{}
 			if resp.Notifications.SyncDisabledWarning.Email == nil {
 				r.Notifications.SyncDisabledWarning.Email = nil
 			} else {
+				r.Notifications.SyncDisabledWarning.Email = &tfTypes.EmailNotificationConfig{}
 				r.Notifications.SyncDisabledWarning.Email.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabledWarning.Email.Enabled)
 			}
 			if resp.Notifications.SyncDisabledWarning.Webhook == nil {
 				r.Notifications.SyncDisabledWarning.Webhook = nil
 			} else {
+				r.Notifications.SyncDisabledWarning.Webhook = &tfTypes.WebhookNotificationConfig{}
 				r.Notifications.SyncDisabledWarning.Webhook.Enabled = types.BoolPointerValue(resp.Notifications.SyncDisabledWarning.Webhook.Enabled)
 				r.Notifications.SyncDisabledWarning.Webhook.URL = types.StringPointerValue(resp.Notifications.SyncDisabledWarning.Webhook.URL)
 			}

--- a/scripts/patch_workspace_notifications.py
+++ b/scripts/patch_workspace_notifications.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-"""Patch workspace SDK files to initialize Notifications pointer before access.
+"""Patch workspace SDK files to initialize nested Notifications pointers.
 
 After Speakeasy regenerates workspace_data_source_sdk.go and workspace_resource_sdk.go,
-the generated RefreshFromSharedWorkspaceResponse method accesses r.Notifications.ConnectionUpdate
-without first initializing r.Notifications (which is a *tfTypes.NotificationsConfig pointer,
-nil by default). This causes a SIGSEGV nil pointer dereference.
+the generated RefreshFromSharedWorkspaceResponse method accesses nested pointer fields
+(r.Notifications, r.Notifications.<SubType>, r.Notifications.<SubType>.Email, etc.)
+without first initializing them. All these are nil by default, causing SIGSEGV panics.
 
-This script injects:
-  1. The missing tfTypes import
-  2. An initialization line: r.Notifications = &tfTypes.NotificationsConfig{}
+This script injects initialization lines at three levels:
+  1. Top-level:   r.Notifications = &tfTypes.NotificationsConfig{}
+  2. Sub-type:    r.Notifications.<SubType> = &tfTypes.NotificationConfig{}
+  3. Leaf:        r.Notifications.<SubType>.Email = &tfTypes.EmailNotificationConfig{}
+                  r.Notifications.<SubType>.Webhook = &tfTypes.WebhookNotificationConfig{}
 
 Fixes: https://github.com/airbytehq/terraform-provider-airbyte/issues/398
+       https://github.com/airbytehq/terraform-provider-airbyte/issues/413
 
 Usage:
     python3 scripts/patch_workspace_notifications.py
@@ -31,12 +34,50 @@ TARGET_FILES = [
 # The import we need to add (tfTypes alias for the types package)
 TFTYPES_IMPORT = '\ttfTypes "github.com/airbytehq/terraform-provider-airbyte/internal/provider/types"'
 
-# The anchor line after which we insert the Notifications initialization.
-# This is the last assignment before the first r.Notifications access.
+# The anchor line after which we insert the top-level Notifications initialization.
 ANCHOR_LINE = "\t\tr.Name = types.StringValue(resp.Name)"
 
-# The initialization line to insert after the anchor.
+# The top-level initialization line.
 INIT_LINE = "\t\tr.Notifications = &tfTypes.NotificationsConfig{}"
+
+# The 6 notification sub-types whose pointers need initialization.
+NOTIFICATION_SUB_TYPES = [
+    "ConnectionUpdate",
+    "ConnectionUpdateActionRequired",
+    "Failure",
+    "Success",
+    "SyncDisabled",
+    "SyncDisabledWarning",
+]
+
+
+def _inject_after_else(content: str, anchor: str, init_line: str) -> str:
+    """Find 'anchor ... } else {' and inject init_line after the else brace.
+
+    The anchor is a line like 'if resp.Notifications.Foo == nil {'.
+    After the matching '} else {', we inject the init_line on the next line.
+    Returns the content unchanged if already patched or anchor not found.
+    """
+    idx = content.find(anchor)
+    if idx == -1:
+        return content
+
+    # Find the '} else {' that follows this anchor
+    else_pattern = "} else {"
+    search_start = idx + len(anchor)
+    else_idx = content.find(else_pattern, search_start)
+    if else_idx == -1:
+        return content
+
+    insert_point = else_idx + len(else_pattern)
+
+    # Check if init_line is already present right after the else
+    after_else = content[insert_point:insert_point + len(init_line) + 10]
+    if init_line.strip() in after_else:
+        return content
+
+    content = content[:insert_point] + "\n" + init_line + content[insert_point:]
+    return content
 
 
 def patch_file(filepath: Path) -> bool:
@@ -47,26 +88,20 @@ def patch_file(filepath: Path) -> bool:
 
     content = filepath.read_text()
     original = content
-    changed = False
 
     # --- Step 1: Add tfTypes import if missing ---
     if TFTYPES_IMPORT not in content:
-        # Find the import block and insert before the closing paren
         import_close = content.find("\n)\n")
         if import_close == -1:
             print(f"ERROR: Could not find import block closing in {filepath}", file=sys.stderr)
             sys.exit(1)
         content = content[:import_close] + "\n" + TFTYPES_IMPORT + content[import_close:]
-        changed = True
         print(f"  Added tfTypes import to {filepath.name}")
     else:
         print(f"  Skipping tfTypes import in {filepath.name} (already present)")
 
-    # --- Step 2: Add Notifications initialization ---
-    if INIT_LINE in content:
-        print(f"  Skipping Notifications init in {filepath.name} (already patched)")
-    else:
-        # Validate anchor exists exactly once in RefreshFromSharedWorkspaceResponse
+    # --- Step 2: Add top-level Notifications initialization ---
+    if INIT_LINE not in content:
         anchor_count = content.count(ANCHOR_LINE)
         if anchor_count == 0:
             print(
@@ -83,24 +118,42 @@ def patch_file(filepath: Path) -> bool:
             )
             sys.exit(1)
 
-        # Insert the init line after the anchor
         anchor_idx = content.index(ANCHOR_LINE)
         insert_point = anchor_idx + len(ANCHOR_LINE)
         content = content[:insert_point] + "\n" + INIT_LINE + content[insert_point:]
-        changed = True
-        print(f"  Added Notifications init to {filepath.name}")
+        print(f"  Added top-level Notifications init to {filepath.name}")
+    else:
+        print(f"  Skipping top-level Notifications init in {filepath.name} (already patched)")
 
+    # --- Step 3: Add sub-type and leaf pointer initializations ---
+    for sub_type in NOTIFICATION_SUB_TYPES:
+        # Sub-type level: after 'if resp.Notifications.<SubType> == nil { ... } else {'
+        sub_anchor = f"\t\tif resp.Notifications.{sub_type} == nil {{"
+        sub_init = f"\t\t\tr.Notifications.{sub_type} = &tfTypes.NotificationConfig{{}}"
+        content = _inject_after_else(content, sub_anchor, sub_init)
+
+        # Email level: after 'if resp.Notifications.<SubType>.Email == nil { ... } else {'
+        email_anchor = f"\t\t\tif resp.Notifications.{sub_type}.Email == nil {{"
+        email_init = f"\t\t\t\tr.Notifications.{sub_type}.Email = &tfTypes.EmailNotificationConfig{{}}"
+        content = _inject_after_else(content, email_anchor, email_init)
+
+        # Webhook level: after 'if resp.Notifications.<SubType>.Webhook == nil { ... } else {'
+        webhook_anchor = f"\t\t\tif resp.Notifications.{sub_type}.Webhook == nil {{"
+        webhook_init = f"\t\t\t\tr.Notifications.{sub_type}.Webhook = &tfTypes.WebhookNotificationConfig{{}}"
+        content = _inject_after_else(content, webhook_anchor, webhook_init)
+
+    changed = content != original
     if changed:
         filepath.write_text(content)
         print(f"  Patched {filepath}")
     else:
         print(f"  No changes needed for {filepath.name}")
 
-    return content != original
+    return changed
 
 
 def main() -> None:
-    print("Patching workspace SDK files to fix Notifications nil pointer...")
+    print("Patching workspace SDK files to fix Notifications nil pointer dereferences...")
     any_changed = False
     for filename in TARGET_FILES:
         filepath = PROVIDER_DIR / filename

--- a/scripts/patch_workspace_notifications.py
+++ b/scripts/patch_workspace_notifications.py
@@ -56,18 +56,32 @@ def _inject_after_else(content: str, anchor: str, init_line: str) -> str:
 
     The anchor is a line like 'if resp.Notifications.Foo == nil {'.
     After the matching '} else {', we inject the init_line on the next line.
-    Returns the content unchanged if already patched or anchor not found.
+    Returns the content unchanged only if already patched; otherwise fails fast
+    when the expected generated-code structure is not found.
     """
     idx = content.find(anchor)
     if idx == -1:
-        return content
+        raise ValueError(
+            f"Failed to apply notification patch: anchor not found: {anchor!r}"
+        )
+
+    # Validate anchor appears exactly once
+    anchor_count = content.count(anchor)
+    if anchor_count != 1:
+        raise ValueError(
+            f"Failed to apply notification patch: anchor found {anchor_count} times "
+            f"(expected 1): {anchor!r}"
+        )
 
     # Find the '} else {' that follows this anchor
     else_pattern = "} else {"
     search_start = idx + len(anchor)
     else_idx = content.find(else_pattern, search_start)
     if else_idx == -1:
-        return content
+        raise ValueError(
+            f"Failed to apply notification patch: "
+            f"expected {else_pattern!r} after anchor {anchor!r}"
+        )
 
     insert_point = else_idx + len(else_pattern)
 
@@ -126,21 +140,25 @@ def patch_file(filepath: Path) -> bool:
         print(f"  Skipping top-level Notifications init in {filepath.name} (already patched)")
 
     # --- Step 3: Add sub-type and leaf pointer initializations ---
-    for sub_type in NOTIFICATION_SUB_TYPES:
-        # Sub-type level: after 'if resp.Notifications.<SubType> == nil { ... } else {'
-        sub_anchor = f"\t\tif resp.Notifications.{sub_type} == nil {{"
-        sub_init = f"\t\t\tr.Notifications.{sub_type} = &tfTypes.NotificationConfig{{}}"
-        content = _inject_after_else(content, sub_anchor, sub_init)
+    try:
+        for sub_type in NOTIFICATION_SUB_TYPES:
+            # Sub-type level: after 'if resp.Notifications.<SubType> == nil { ... } else {'
+            sub_anchor = f"\t\tif resp.Notifications.{sub_type} == nil {{"
+            sub_init = f"\t\t\tr.Notifications.{sub_type} = &tfTypes.NotificationConfig{{}}"
+            content = _inject_after_else(content, sub_anchor, sub_init)
 
-        # Email level: after 'if resp.Notifications.<SubType>.Email == nil { ... } else {'
-        email_anchor = f"\t\t\tif resp.Notifications.{sub_type}.Email == nil {{"
-        email_init = f"\t\t\t\tr.Notifications.{sub_type}.Email = &tfTypes.EmailNotificationConfig{{}}"
-        content = _inject_after_else(content, email_anchor, email_init)
+            # Email level: after 'if resp.Notifications.<SubType>.Email == nil { ... } else {'
+            email_anchor = f"\t\t\tif resp.Notifications.{sub_type}.Email == nil {{"
+            email_init = f"\t\t\t\tr.Notifications.{sub_type}.Email = &tfTypes.EmailNotificationConfig{{}}"
+            content = _inject_after_else(content, email_anchor, email_init)
 
-        # Webhook level: after 'if resp.Notifications.<SubType>.Webhook == nil { ... } else {'
-        webhook_anchor = f"\t\t\tif resp.Notifications.{sub_type}.Webhook == nil {{"
-        webhook_init = f"\t\t\t\tr.Notifications.{sub_type}.Webhook = &tfTypes.WebhookNotificationConfig{{}}"
-        content = _inject_after_else(content, webhook_anchor, webhook_init)
+            # Webhook level: after 'if resp.Notifications.<SubType>.Webhook == nil { ... } else {'
+            webhook_anchor = f"\t\t\tif resp.Notifications.{sub_type}.Webhook == nil {{"
+            webhook_init = f"\t\t\t\tr.Notifications.{sub_type}.Webhook = &tfTypes.WebhookNotificationConfig{{}}"
+            content = _inject_after_else(content, webhook_anchor, webhook_init)
+    except ValueError as exc:
+        print(f"ERROR in {filepath.name}: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     changed = content != original
     if changed:


### PR DESCRIPTION
## Summary

Completes the fix for #413 (follow-up to the incomplete fix in PR #405).

PR #405 initialized only the top-level `r.Notifications` pointer, but the generated `RefreshFromSharedWorkspaceResponse` method also dereferences nested pointers at two deeper levels — the 6 notification sub-type pointers (`ConnectionUpdate`, `Failure`, `Success`, etc.) and their `Email`/`Webhook` children. When the API returns non-nil notification settings, these uninitialized pointers cause a SIGSEGV panic.

**Changes:**
- **`workspace_data_source_sdk.go` / `workspace_resource_sdk.go`**: Added 18 pointer initializations per file (6 sub-types × 3 levels: sub-type, Email, Webhook) in the `} else {` branches where the API value is non-nil
- **`scripts/patch_workspace_notifications.py`**: Rewrote to inject all nested initializations (not just top-level), using a new `_inject_after_else()` helper. Patch is idempotent, fails fast on missing anchors, validates anchor uniqueness, and references #413
- **`workspace_notifications_test.go`**: 6 table-driven test cases exercising `RefreshFromSharedWorkspaceResponse` on both resource and data source models with various nil/non-nil notification combinations, plus value-preservation assertions

## E2E Verification

Bug reproduced and fix confirmed against a live Airbyte Cloud workspace with all 6 notification sub-types configured (email + webhook):

1. **v1.1.1 (published release)**: `terraform plan` → SIGSEGV at `workspace_data_source_sdk.go:27`
2. **PR #420 binary (dev override)**: `terraform plan` → all 6 notification sub-types read successfully with correct Email/Webhook values, no panic

Terminal recording of both steps: ![E2E test recording](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaXE0N0YzeHhWMzlHMFpobiIsInVzZXJfaWQiOiJnaXRodWJ8MTgxNTA2NTEiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfaXE0N0YzeHhWMzlHMFpobi9kNjZjMjNjMi0wMjc2LTQ0MjgtOTE2MC1jNzAzODQzY2M0NTYiLCJpYXQiOjE3NzYxOTMwODEsImV4cCI6MTc3Njc5Nzg4MX0.VnwcEZmITlcYormRy_g88WlNMd_BA1O85QOTZcZvlCc)

[View original video (rec-a6d4816c01574838be62e054ab1b8b3e-edited.mp4)](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaXE0N0YzeHhWMzlHMFpobiIsInVzZXJfaWQiOiJnaXRodWJ8MTgxNTA2NTEiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfaXE0N0YzeHhWMzlHMFpobi82MjAyMGQzOS01NzZhLTQxMDgtOWY3My05ZjQ4YzI3YjAyMzgiLCJpYXQiOjE3NzYxOTMwODEsImV4cCI6MTc3Njc5Nzg4MX0.3EeOIos_gL5JIz_B5j1LdTNolVPvn5o_iFP9kSyJn2M)

## Review & Testing Checklist for Human

- [ ] **Verify `_inject_after_else()` targets the correct `} else {`**: The helper finds the *first* `} else {` after each anchor string. If Speakeasy ever adds intermediate else branches between the nil check and the field assignments, the injection could land in the wrong location. Spot-check one sub-type in the patched Go files to confirm.
- [ ] **Run the patch after a fresh `/generate`**: The string-matching approach depends on exact indentation and variable naming in generated code. Verify the patch still applies correctly against current Speakeasy output.
- [ ] **Verify the `workspace` resource path (not just data source)**: The E2E test above used `data.airbyte_workspace`; consider also testing `resource.airbyte_workspace` with `terraform import` or a managed workspace to confirm the resource SDK path is equally fixed.

### Notes
- Patch script idempotency verified (running twice produces no additional changes)
- `go build ./...`, `go vet`, and `go test ./internal/provider/ -run TestWorkspace.*Notification` all pass locally
- Patch script now fails fast with `ValueError` if anchors are missing or non-unique (addresses Copilot review feedback)

Link to Devin session: https://app.devin.ai/sessions/08775464b5b7495187359ccc1f88a48f
Requested by: @aaronsteers