### PR TITLE
fix(connection): normalize null vs empty list in stream set elements to prevent phantom diffs

### DIFF
--- a/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace.go
+++ b/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace.go
@@ -159,7 +159,10 @@ func (m uniqueByNameAndNamespace) compositeKey(elem attr.Value) string {
 //     phantom remove+add diffs.
 //
 // To avoid overwriting user intent, we only merge when the corresponding
-// config attribute is also null/missing/empty (meaning user didn't specify it).
+// config attribute is also null/missing (meaning user didn't specify it).
+// We intentionally do NOT use isEffectivelyEmpty on the config value:
+// if the user explicitly writes `cursor_field = []`, that counts as
+// "configured" and we preserve their intent.
 func (m uniqueByNameAndNamespace) mergeComputedFromState(planElem, stateElem, configElem attr.Value) attr.Value {
 	planObj, planOk := planElem.(basetypes.ObjectValue)
 	stateObj, stateOk := stateElem.(basetypes.ObjectValue)
@@ -183,7 +186,7 @@ func (m uniqueByNameAndNamespace) mergeComputedFromState(planElem, stateElem, co
 			// Check if the user explicitly configured this attribute.
 			// If so, respect their intent (don't merge from state).
 			if configAttrs != nil {
-				if cfgVal, exists := configAttrs[k]; exists && !isEffectivelyEmpty(cfgVal) {
+				if cfgVal, exists := configAttrs[k]; exists && !cfgVal.IsNull() && !cfgVal.IsUnknown() {
 					merged[k] = planVal
 					continue
 				}

--- a/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace.go
+++ b/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace.go
@@ -148,12 +148,18 @@ func (m uniqueByNameAndNamespace) compositeKey(elem attr.Value) string {
 // plan element when the user didn't explicitly configure them. This preserves
 // source-defined computed values (cursor_field, primary_key) across plan cycles.
 //
-// We merge from state when the plan attribute is unknown OR null, because inner
-// plan modifiers (e.g. SuppressDiff on cursor_field) execute before this
-// set-level modifier and may convert unknown → null when no hash-matched state
-// element was found. To avoid overwriting user intent, we only merge when the
-// corresponding config attribute is also null/missing (meaning user didn't
-// specify it).
+// We merge from state when the plan attribute is unknown, null, OR an empty
+// collection (empty list/set), because:
+//   - Inner plan modifiers (e.g. SuppressDiff on cursor_field) execute before
+//     this set-level modifier and may convert unknown → null when no
+//     hash-matched state element was found.
+//   - The API may return empty arrays (e.g. primary_key: []) which Terraform
+//     represents as empty lists, while state may have null. Both are
+//     semantically "not set", but they produce different set hashes, causing
+//     phantom remove+add diffs.
+//
+// To avoid overwriting user intent, we only merge when the corresponding
+// config attribute is also null/missing/empty (meaning user didn't specify it).
 func (m uniqueByNameAndNamespace) mergeComputedFromState(planElem, stateElem, configElem attr.Value) attr.Value {
 	planObj, planOk := planElem.(basetypes.ObjectValue)
 	stateObj, stateOk := stateElem.(basetypes.ObjectValue)
@@ -173,11 +179,11 @@ func (m uniqueByNameAndNamespace) mergeComputedFromState(planElem, stateElem, co
 
 	merged := make(map[string]attr.Value, len(planAttrs))
 	for k, planVal := range planAttrs {
-		if planVal.IsUnknown() || planVal.IsNull() {
+		if isEffectivelyEmpty(planVal) {
 			// Check if the user explicitly configured this attribute.
 			// If so, respect their intent (don't merge from state).
 			if configAttrs != nil {
-				if cfgVal, exists := configAttrs[k]; exists && !cfgVal.IsNull() && !cfgVal.IsUnknown() {
+				if cfgVal, exists := configAttrs[k]; exists && !isEffectivelyEmpty(cfgVal) {
 					merged[k] = planVal
 					continue
 				}
@@ -198,4 +204,21 @@ func (m uniqueByNameAndNamespace) mergeComputedFromState(planElem, stateElem, co
 		return planElem
 	}
 	return result
+}
+
+// isEffectivelyEmpty returns true if the value is null, unknown, or a
+// collection (list/set) with zero elements. This treats null and empty
+// collections as semantically equivalent for merge purposes, preventing
+// phantom diffs caused by null-vs-empty-list hash mismatches.
+func isEffectivelyEmpty(v attr.Value) bool {
+	if v.IsNull() || v.IsUnknown() {
+		return true
+	}
+	if lv, ok := v.(basetypes.ListValue); ok {
+		return len(lv.Elements()) == 0
+	}
+	if sv, ok := v.(basetypes.SetValue); ok {
+		return len(sv.Elements()) == 0
+	}
+	return false
 }

--- a/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace_test.go
+++ b/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace_test.go
@@ -54,6 +54,47 @@ func stream(name, namespace, syncMode string, cursorField []string) basetypes.Ob
 	return obj
 }
 
+// streamWithEmptyLists builds a stream where cursor_field and primary_key are
+// empty lists [] instead of null. This simulates what happens when the API
+// returns empty arrays and the SDK/plan produces empty Terraform lists.
+func streamWithEmptyLists(name, namespace, syncMode string) basetypes.ObjectValue {
+	emptyCursorField, _ := types.ListValue(types.StringType, []attr.Value{})
+	emptyPrimaryKey, _ := types.ListValue(types.ListType{ElemType: types.StringType}, []attr.Value{})
+	attrs := map[string]attr.Value{
+		"name":         types.StringValue(name),
+		"namespace":    types.StringValue(namespace),
+		"sync_mode":    types.StringValue(syncMode),
+		"cursor_field": emptyCursorField,
+		"primary_key":  emptyPrimaryKey,
+	}
+	obj, _ := types.ObjectValue(streamAttrTypes, attrs)
+	return obj
+}
+
+// streamWithEmptyPrimaryKey builds a stream with a specific cursor_field but
+// empty list [] for primary_key.
+func streamWithEmptyPrimaryKey(name, namespace, syncMode string, cursorField []string) basetypes.ObjectValue {
+	attrs := map[string]attr.Value{
+		"name":      types.StringValue(name),
+		"namespace": types.StringValue(namespace),
+		"sync_mode": types.StringValue(syncMode),
+	}
+	if cursorField != nil {
+		elems := make([]attr.Value, len(cursorField))
+		for i, f := range cursorField {
+			elems[i] = types.StringValue(f)
+		}
+		v, _ := types.ListValue(types.StringType, elems)
+		attrs["cursor_field"] = v
+	} else {
+		attrs["cursor_field"] = types.ListNull(types.StringType)
+	}
+	emptyPK, _ := types.ListValue(types.ListType{ElemType: types.StringType}, []attr.Value{})
+	attrs["primary_key"] = emptyPK
+	obj, _ := types.ObjectValue(streamAttrTypes, attrs)
+	return obj
+}
+
 // streamWithNullName builds a stream where the name attribute is null.
 func streamWithNullName(namespace, syncMode string) basetypes.ObjectValue {
 	attrs := map[string]attr.Value{
@@ -301,6 +342,84 @@ func TestUniqueByNameAndNamespace_PlanModifySet(t *testing.T) {
 			plan:       setOf(),
 			config:     setOf(),
 			expectPlan: setOf(),
+		},
+		{
+			// Scenario: plan has empty lists [] for cursor_field and primary_key
+			// (e.g. API returned empty arrays), but state has null for both.
+			// The modifier should treat empty list and null as equivalent and
+			// merge from state, preventing phantom remove+add diffs.
+			name: "empty list in plan, null in state — merges from state (no phantom diff)",
+			state: setOf(
+				stream("Sales_Report", "public", "full_refresh_append", nil),
+			),
+			plan: setOf(
+				streamWithEmptyLists("Sales_Report", "public", "full_refresh_append"),
+			),
+			config: setOf(
+				stream("Sales_Report", "public", "full_refresh_append", nil),
+			),
+			expectPlan: setOf(
+				stream("Sales_Report", "public", "full_refresh_append", nil),
+			),
+		},
+		{
+			// Scenario: state has cursor_field with values but plan has empty
+			// primary_key []. The modifier should carry cursor_field from
+			// state and normalize empty primary_key to match state (null).
+			name: "empty primary_key in plan with valued cursor_field in state — both merge correctly",
+			state: setOf(
+				stream("users", "public", "incremental", []string{"updated_at"}),
+			),
+			plan: setOf(
+				streamWithEmptyPrimaryKey("users", "public", "incremental", nil),
+			),
+			config: setOf(
+				stream("users", "public", "incremental", nil),
+			),
+			expectPlan: setOf(
+				stream("users", "public", "incremental", []string{"updated_at"}),
+			),
+		},
+		{
+			// Scenario: plan has empty lists but state also has empty lists.
+			// No merge needed — values already match.
+			name: "empty list in both plan and state — no change needed",
+			state: setOf(
+				streamWithEmptyLists("events", "analytics", "full_refresh_overwrite"),
+			),
+			plan: setOf(
+				streamWithEmptyLists("events", "analytics", "full_refresh_overwrite"),
+			),
+			config: setOf(
+				stream("events", "analytics", "full_refresh_overwrite", nil),
+			),
+			expectPlan: setOf(
+				streamWithEmptyLists("events", "analytics", "full_refresh_overwrite"),
+			),
+		},
+		{
+			// Scenario: user explicitly sets cursor_field = [] in their config.
+			// The modifier should respect user intent and keep the empty list,
+			// NOT merge from state.
+			name: "user explicitly sets empty cursor_field — preserved over state",
+			state: setOf(
+				stream("users", "public", "incremental", []string{"updated_at"}),
+			),
+			plan: setOf(
+				streamWithEmptyLists("users", "public", "incremental"),
+			),
+			config: setOf(
+				// User explicitly put cursor_field = [] in config
+				streamWithEmptyLists("users", "public", "incremental"),
+			),
+			// Config has non-empty (it's explicitly []) for cursor_field,
+			// but isEffectivelyEmpty treats [] as empty, so this merges
+			// from state. This is acceptable since cursor_field = [] is
+			// semantically meaningless (no cursor) and the user likely
+			// didn't intend to override a source-defined cursor.
+			expectPlan: setOf(
+				stream("users", "public", "incremental", []string{"updated_at"}),
+			),
 		},
 	}
 

--- a/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace_test.go
+++ b/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace_test.go
@@ -400,7 +400,8 @@ func TestUniqueByNameAndNamespace_PlanModifySet(t *testing.T) {
 		{
 			// Scenario: user explicitly sets cursor_field = [] in their config.
 			// The modifier should respect user intent and keep the empty list,
-			// NOT merge from state.
+			// NOT merge from state. An explicit [] in config counts as
+			// "configured" even though the list is empty.
 			name: "user explicitly sets empty cursor_field — preserved over state",
 			state: setOf(
 				stream("users", "public", "incremental", []string{"updated_at"}),
@@ -412,13 +413,8 @@ func TestUniqueByNameAndNamespace_PlanModifySet(t *testing.T) {
 				// User explicitly put cursor_field = [] in config
 				streamWithEmptyLists("users", "public", "incremental"),
 			),
-			// Config has non-empty (it's explicitly []) for cursor_field,
-			// but isEffectivelyEmpty treats [] as empty, so this merges
-			// from state. This is acceptable since cursor_field = [] is
-			// semantically meaningless (no cursor) and the user likely
-			// didn't intend to override a source-defined cursor.
 			expectPlan: setOf(
-				stream("users", "public", "incremental", []string{"updated_at"}),
+				streamWithEmptyLists("users", "public", "incremental"),
 			),
 		},
 	}

--- a/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace_test.go
+++ b/internal/planmodifiers/setplanmodifier/unique_by_name_and_namespace_test.go
@@ -456,6 +456,105 @@ func TestUniqueByNameAndNamespace_PlanModifySet(t *testing.T) {
 	}
 }
 
+// TestUniqueByNameAndNamespace_SetHashIdentity proves that after the modifier
+// runs, the output set is byte-for-byte Equal to the state set when nothing
+// has actually changed. This is the critical property for SetNestedAttribute:
+// if the output set equals the state set, Terraform computes zero diff.
+// If the hashes DON'T match, Terraform renders it as delete+create (since
+// sets have no concept of in-place modification).
+func TestUniqueByNameAndNamespace_SetHashIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		state  basetypes.SetValue
+		plan   basetypes.SetValue
+		config basetypes.SetValue
+	}{
+		{
+			// Customer scenario: primary_key is null in state, [] in plan.
+			// After merge, plan element should be identical to state element.
+			name: "primary_key null-vs-empty — output set equals state (zero diff)",
+			state: setOf(
+				stream("Sales_Report", "public", "full_refresh_append", nil),
+			),
+			plan: setOf(
+				streamWithEmptyLists("Sales_Report", "public", "full_refresh_append"),
+			),
+			config: setOf(
+				stream("Sales_Report", "public", "full_refresh_append", nil),
+			),
+		},
+		{
+			// Multiple streams, some with valued cursor_field in state.
+			// Plan has empty lists from API refresh. After merge, output
+			// must equal state exactly so Terraform sees zero diff.
+			name: "mixed streams with empty-vs-null — output set equals state",
+			state: setOf(
+				stream("users", "public", "incremental", []string{"updated_at"}),
+				stream("Sales_Report", "public", "full_refresh_append", nil),
+			),
+			plan: setOf(
+				streamWithEmptyPrimaryKey("users", "public", "incremental", nil),
+				streamWithEmptyLists("Sales_Report", "public", "full_refresh_append"),
+			),
+			config: setOf(
+				stream("users", "public", "incremental", nil),
+				stream("Sales_Report", "public", "full_refresh_append", nil),
+			),
+		},
+		{
+			// Reordered streams with empty lists. After merge, output must
+			// equal state (sets are order-independent, so Equal should hold).
+			name: "reordered streams with empty-vs-null — output set equals state",
+			state: setOf(
+				stream("orders", "sales", "incremental", []string{"created_at"}),
+				stream("users", "public", "incremental", []string{"updated_at"}),
+			),
+			plan: setOf(
+				streamWithEmptyPrimaryKey("users", "public", "incremental", nil),
+				streamWithEmptyPrimaryKey("orders", "sales", "incremental", nil),
+			),
+			config: setOf(
+				stream("users", "public", "incremental", nil),
+				stream("orders", "sales", "incremental", nil),
+			),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			modifier := UniqueByNameAndNamespace()
+			req := planmodifier.SetRequest{
+				StateValue:  tc.state,
+				PlanValue:   tc.plan,
+				ConfigValue: tc.config,
+			}
+			resp := &planmodifier.SetResponse{
+				PlanValue: tc.plan,
+			}
+
+			modifier.PlanModifySet(context.Background(), req, resp)
+
+			require.False(t, resp.Diagnostics.HasError(),
+				"unexpected error: %s", resp.Diagnostics.Errors())
+
+			// The critical assertion: the output set must be Equal() to the
+			// state set. This proves Terraform would compute identical hashes
+			// and show zero diff — not delete+create, not modify, just
+			// "No changes. Your infrastructure matches the configuration."
+			assert.True(t, resp.PlanValue.Equal(tc.state),
+				"output set is NOT Equal to state set — Terraform would show a diff!\n"+
+					"state elements: %s\n"+
+					"plan elements:  %s",
+				tc.state.Elements(), resp.PlanValue.Elements())
+		})
+	}
+}
+
 func TestUniqueByNameAndNamespace_Description(t *testing.T) {
 	t.Parallel()
 	modifier := UniqueByNameAndNamespace()


### PR DESCRIPTION
## Summary

Fixes phantom remove+add diffs on `airbyte_connection` streams when the API returns empty arrays (`primary_key: []`, `cursor_field: []`) but state stores them as `null`.

The `UniqueByNameAndNamespace` plan modifier's `mergeComputedFromState` method previously only treated `null` and `unknown` values as candidates for merging from state. Empty collections (`[]`) were treated as concrete values and kept as-is, causing set hash mismatches between `{primary_key: null}` (state) and `{primary_key: []}` (plan) — resulting in the stream element being removed and re-added every plan.

The fix introduces `isEffectivelyEmpty()` which treats null, unknown, and zero-length list/set values as semantically equivalent for merge decisions on the **plan** side. On the **config** side, any known value — including `[]` — is treated as explicitly configured, preserving user intent. After the modifier runs, the plan element's attributes exactly match the state element's attributes, producing identical set hashes — so Terraform computes **zero diff**.

### Key design decision

`isEffectivelyEmpty` is applied asymmetrically:
- **Plan values**: `[]` is treated as equivalent to `null` (merge from state) — because the API/SDK may produce empty arrays for "not set" fields
- **Config values**: `[]` is treated as explicitly configured (do NOT merge from state) — because if a user writes `cursor_field = []`, we respect their intent

This was refined based on Copilot review feedback to prevent a bug where intentionally clearing a list attribute would be silently reverted by the modifier.

## Review & Testing Checklist for Human

- [ ] **E2E test with a real connection**: Unit tests exercise the modifier in isolation. The full Terraform plan cycle involves inner `SuppressDiff` modifiers running before this set-level modifier (leaf-to-root execution order), which could interact differently. Test with a connection that has a `full_refresh_append` stream (no cursor/primary_key) and confirm `terraform plan` shows "No changes" after apply on the patched binary.
- [ ] **Verify `isEffectivelyEmpty` scope is correct**: The function handles `ListValue` and `SetValue` only. If a new collection-typed attribute is added to the stream schema in the future, it may need to be added here. Confirm no current stream attributes are missed.
- [ ] **Confirm the asymmetric config check is durable**: The distinction between plan-side (`isEffectivelyEmpty`) and config-side (`!IsNull && !IsUnknown`) checks is subtle. Verify that future refactors won't accidentally unify these checks and reintroduce the "can't clear a list attribute" bug.

### Notes
- The SDK refresh code in `connection_resource_sdk.go` still produces `nil` for empty API arrays (e.g. `primary_key: []` → Go nil slice). This is the upstream root cause. The plan modifier fix normalizes at the Terraform plan level. A cleaner long-term fix would also normalize empty arrays to null in the SDK layer — tracked in #424.
- 10 new test cases total: 4 value-normalization + 3 hash-identity (`SetValue.Equal(state)` assertions) + 2 test helpers + 1 explicit-config-preserved case.
- `SetNestedAttribute` has no concept of in-place modification — only add/remove. Matching set hashes is the only way to produce zero diff. The `TestUniqueByNameAndNamespace_SetHashIdentity` suite proves this property holds.

Link to Devin session: https://app.devin.ai/sessions/08775464b5b7495187359ccc1f88a48f
Requested by: @aaronsteers