### PR TITLE
feat(data-source): add `connector_registry` attribute to `airbyte_connector_configuration`, update to `composite` registry as default

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,13 +5,13 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.761.11
   generationVersion: 2.881.17
-  releaseVersion: 1.1.4
-  configChecksum: f5c61f295361309282c37ca348840de4
+  releaseVersion: 1.2.0
+  configChecksum: f8ae681aceb81abf3350c60e6e024928
   repoURL: https://github.com/airbytehq/terraform-provider-airbyte.git
 persistentEdits:
-  generation_id: d8b0ab5c-426d-4594-b244-4826c3237d50
-  pristine_commit_hash: 16e7310f74b18a3e60f8878f9db4c340229d1c2d
-  pristine_tree_hash: 3df42f45df566c706c11f1c42bbfbec3178daf58
+  generation_id: d67b3f4f-1e87-4254-b0fc-dde4f2845606
+  pristine_commit_hash: 2b8892821db313b406af987fb498a44e5a5dc4e5
+  pristine_tree_hash: d8980f8a39908bba6244675a9e81a0a7ca43f224
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -74,8 +74,8 @@ trackedFiles:
     pristine_git_object: 8f46fa23e9ff318c727d03f0dcf5a8a677b6e617
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:2b543198f37b628cb6fb2fa2ca16c175a28678f4
-    pristine_git_object: d0dcae0ff9de3ddde70b8315d62c9126cb9b87f4
+    last_write_checksum: sha1:932a4ff77872ef520439fbbbe7cd42a6c07e9f11
+    pristine_git_object: 38f9abd18d44e82acd6d3f9870cda280971276ae
   examples/resources/airbyte_connection/import-by-string-id.tf:
     id: 8c04ff01f5ae
     last_write_checksum: sha1:d0e6ff899bd5da0e7018c9420f4face02263ff4c
@@ -1646,8 +1646,8 @@ trackedFiles:
     pristine_git_object: 5b3dc7c122d8ab08905485342d7474f8f163888d
   internal/sdk/sdk.go:
     id: 02d7190ee502
-    last_write_checksum: sha1:ca1e2e825bf94949b07ddcd14e0ae8b49aa97177
-    pristine_git_object: fc8c862ecec0de83095b68a56f1c4b56d5c7b339
+    last_write_checksum: sha1:be76131e38113035cc76249bd0861714ed8d6fec
+    pristine_git_object: 15942ec4a7c4106969bd32d2cc9ed914ba7c304b
   internal/sdk/sourcedefinitions.go:
     id: 6cda810b4781
     last_write_checksum: sha1:078f7fbb18285e856fbde7c941686d2c8f9cc97f

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -6,7 +6,7 @@ sources:
         sourceBlobDigest: sha256:0cbfff7de7891f5f766611b072dba3678a0f965045f34f9bbf3310e2b8b2f7ce
         tags:
             - latest
-            - main
+            - devin-1777391769-spec-source-override
             - 1.0.0
     my-source:
         sourceNamespace: my-source

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -6,7 +6,7 @@ sources:
         sourceBlobDigest: sha256:0cbfff7de7891f5f766611b072dba3678a0f965045f34f9bbf3310e2b8b2f7ce
         tags:
             - latest
-            - devin-1777391769-spec-source-override
+            - main
             - 1.0.0
     my-source:
         sourceNamespace: my-source

--- a/docs/data-sources/connector_configuration.md
+++ b/docs/data-sources/connector_configuration.md
@@ -61,16 +61,16 @@ data "airbyte_connector_configuration" "postgres" {
 }
 ```
 
-### Override the spec source (OSS, URL, or local file)
+### Override the connector registry
 
-By default, the spec is fetched from the **Cloud** registry. Use `spec_source` to switch to **OSS**, a custom **URL**, or a **local file**:
+By default, the spec is fetched from both **Cloud** and **OSS** registries (composite). Use `connector_registry` to target a specific registry, a custom **URL**, or a **local file**. URLs and file paths must serve well-formatted registry JSON:
 
 ```terraform
-# Use the OSS registry
+# Use the OSS registry only
 data "airbyte_connector_configuration" "postgres_oss" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "oss"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "oss"
 
   configuration = {
     host     = "db.example.com"
@@ -81,9 +81,9 @@ data "airbyte_connector_configuration" "postgres_oss" {
 
 # Use a custom URL
 data "airbyte_connector_configuration" "custom_url" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "https://example.com/my-custom-spec.json"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "https://example.com/my-registry-spec.json"
 
   configuration = {
     host     = "db.example.com"
@@ -94,9 +94,9 @@ data "airbyte_connector_configuration" "custom_url" {
 
 # Use a local file
 data "airbyte_connector_configuration" "local_spec" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "./specs/source-postgres.json"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "./specs/source-postgres.json"
 
   configuration = {
     host     = "db.example.com"
@@ -130,9 +130,9 @@ resource "airbyte_source" "postgres" {
 ### Optional
 
 - `configuration_secrets` (Dynamic, Sensitive) Sensitive configuration values (API keys, passwords, etc.) as an HCL object. These are hidden in Terraform plan output. Keys here are deep-merged with (and override) keys in `configuration`.
+- `connector_registry` (String) Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or a local file path (starting with `/` or `./`) to override the spec source entirely.
 - `connector_version` (String) The version of the connector (e.g. `2.0.0`). If not specified, the latest version is used. When set, the connector spec for that exact version is fetched and used for JSONSchema validation.
 - `ignore_errors` (Boolean) If true, validation errors (including JSONSchema validation) are reported as warnings instead of errors. Defaults to false.
-- `spec_source` (String) Controls where the connector spec is fetched from. Accepted values: `cloud` (default) fetches from the Cloud registry, `oss` fetches from the OSS registry. You can also provide a full URL (starting with `http://` or `https://`) or a local file path to override the spec source entirely.
 
 ### Read-Only
 

--- a/docs/data-sources/connector_configuration.md
+++ b/docs/data-sources/connector_configuration.md
@@ -61,6 +61,51 @@ data "airbyte_connector_configuration" "postgres" {
 }
 ```
 
+### Override the spec source (OSS, URL, or local file)
+
+By default, the spec is fetched from the **Cloud** registry. Use `spec_source` to switch to **OSS**, a custom **URL**, or a **local file**:
+
+```terraform
+# Use the OSS registry
+data "airbyte_connector_configuration" "postgres_oss" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "oss"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+
+# Use a custom URL
+data "airbyte_connector_configuration" "custom_url" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "https://example.com/my-custom-spec.json"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+
+# Use a local file
+data "airbyte_connector_configuration" "local_spec" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "./specs/source-postgres.json"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+```
+
 ### Pass resolved values to a resource
 
 Use the data source outputs to configure an [`airbyte_source`](../resources/source.md) or [`airbyte_destination`](../resources/destination.md) resource:
@@ -87,6 +132,7 @@ resource "airbyte_source" "postgres" {
 - `configuration_secrets` (Dynamic, Sensitive) Sensitive configuration values (API keys, passwords, etc.) as an HCL object. These are hidden in Terraform plan output. Keys here are deep-merged with (and override) keys in `configuration`.
 - `connector_version` (String) The version of the connector (e.g. `2.0.0`). If not specified, the latest version is used. When set, the connector spec for that exact version is fetched and used for JSONSchema validation.
 - `ignore_errors` (Boolean) If true, validation errors (including JSONSchema validation) are reported as warnings instead of errors. Defaults to false.
+- `spec_source` (String) Controls where the connector spec is fetched from. Accepted values: `cloud` (default) fetches from the Cloud registry, `oss` fetches from the OSS registry. You can also provide a full URL (starting with `http://` or `https://`) or a local file path to override the spec source entirely.
 
 ### Read-Only
 

--- a/docs/data-sources/connector_configuration.md
+++ b/docs/data-sources/connector_configuration.md
@@ -96,7 +96,7 @@ data "airbyte_connector_configuration" "custom_url" {
 data "airbyte_connector_configuration" "local_spec" {
   connector_name     = "source-postgres"
   connector_version  = "3.6.28"
-  connector_registry = "./path/to/my-custom-registry.json"
+  connector_registry = "/path/to/my-custom-registry.json"
 
   configuration = {
     host     = "db.example.com"
@@ -130,7 +130,7 @@ resource "airbyte_source" "postgres" {
 ### Optional
 
 - `configuration_secrets` (Dynamic, Sensitive) Sensitive configuration values (API keys, passwords, etc.) as an HCL object. These are hidden in Terraform plan output. Keys here are deep-merged with (and override) keys in `configuration`.
-- `connector_registry` (String) Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or a local file path (starting with `/` or `./`) to override the spec source entirely.
+- `connector_registry` (String) Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or an absolute file path (starting with `/`) to override the spec source entirely.
 - `connector_version` (String) The version of the connector (e.g. `2.0.0`). If not specified, the latest version is used. When set, the connector spec for that exact version is fetched and used for JSONSchema validation.
 - `ignore_errors` (Boolean) If true, validation errors (including JSONSchema validation) are reported as warnings instead of errors. Defaults to false.
 

--- a/docs/data-sources/connector_configuration.md
+++ b/docs/data-sources/connector_configuration.md
@@ -96,7 +96,7 @@ data "airbyte_connector_configuration" "custom_url" {
 data "airbyte_connector_configuration" "local_spec" {
   connector_name     = "source-postgres"
   connector_version  = "3.6.28"
-  connector_registry = "./specs/source-postgres.json"
+  connector_registry = "./path/to/my-custom-registry.json"
 
   configuration = {
     host     = "db.example.com"

--- a/docs/data-sources/connector_configuration.md
+++ b/docs/data-sources/connector_configuration.md
@@ -130,7 +130,7 @@ resource "airbyte_source" "postgres" {
 ### Optional
 
 - `configuration_secrets` (Dynamic, Sensitive) Sensitive configuration values (API keys, passwords, etc.) as an HCL object. These are hidden in Terraform plan output. Keys here are deep-merged with (and override) keys in `configuration`.
-- `connector_registry` (String) Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or an absolute file path (starting with `/`) to override the spec source entirely.
+- `connector_registry` (String) Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `composite` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or an absolute file path (starting with `/`) to override the spec source entirely.
 - `connector_version` (String) The version of the connector (e.g. `2.0.0`). If not specified, the latest version is used. When set, the connector spec for that exact version is fetched and used for JSONSchema validation.
 - `ignore_errors` (Boolean) If true, validation errors (including JSONSchema validation) are reported as warnings instead of errors. Defaults to false.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "1.1.4"
+      version = "1.2.0"
     }
   }
 }

--- a/examples/data-sources/airbyte_connector_configuration/data-source.tf
+++ b/examples/data-sources/airbyte_connector_configuration/data-source.tf
@@ -31,11 +31,11 @@ data "airbyte_connector_configuration" "postgres" {
   }
 }
 
-# Validate against the OSS registry instead of Cloud
+# Validate against the OSS registry instead of the default (cloud_and_oss)
 data "airbyte_connector_configuration" "postgres_oss" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "oss"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "oss"
 
   configuration = {
     host     = "db.example.com"
@@ -44,11 +44,11 @@ data "airbyte_connector_configuration" "postgres_oss" {
   }
 }
 
-# Override spec source with a custom URL
+# Override registry source with a custom URL (must serve well-formatted registry JSON)
 data "airbyte_connector_configuration" "custom_url" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "https://example.com/my-custom-spec.json"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "https://example.com/my-registry-spec.json"
 
   configuration = {
     host     = "db.example.com"
@@ -57,11 +57,11 @@ data "airbyte_connector_configuration" "custom_url" {
   }
 }
 
-# Override spec source with a local file path
+# Override registry source with a local file (must contain well-formatted registry JSON)
 data "airbyte_connector_configuration" "local_spec" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "./specs/source-postgres.json"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "./specs/source-postgres.json"
 
   configuration = {
     host     = "db.example.com"

--- a/examples/data-sources/airbyte_connector_configuration/data-source.tf
+++ b/examples/data-sources/airbyte_connector_configuration/data-source.tf
@@ -61,7 +61,7 @@ data "airbyte_connector_configuration" "custom_url" {
 data "airbyte_connector_configuration" "local_spec" {
   connector_name     = "source-postgres"
   connector_version  = "3.6.28"
-  connector_registry = "./specs/source-postgres.json"
+  connector_registry = "./path/to/my-custom-registry.json"
 
   configuration = {
     host     = "db.example.com"

--- a/examples/data-sources/airbyte_connector_configuration/data-source.tf
+++ b/examples/data-sources/airbyte_connector_configuration/data-source.tf
@@ -31,7 +31,7 @@ data "airbyte_connector_configuration" "postgres" {
   }
 }
 
-# Validate against the OSS registry instead of the default (cloud_and_oss)
+# Validate against the OSS registry instead of the default (composite)
 data "airbyte_connector_configuration" "postgres_oss" {
   connector_name     = "source-postgres"
   connector_version  = "3.6.28"

--- a/examples/data-sources/airbyte_connector_configuration/data-source.tf
+++ b/examples/data-sources/airbyte_connector_configuration/data-source.tf
@@ -31,6 +31,45 @@ data "airbyte_connector_configuration" "postgres" {
   }
 }
 
+# Validate against the OSS registry instead of Cloud
+data "airbyte_connector_configuration" "postgres_oss" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "oss"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+
+# Override spec source with a custom URL
+data "airbyte_connector_configuration" "custom_url" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "https://example.com/my-custom-spec.json"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+
+# Override spec source with a local file path
+data "airbyte_connector_configuration" "local_spec" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "./specs/source-postgres.json"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+
 # Pass the resolved values to an airbyte_source resource
 resource "airbyte_source" "postgres" {
   name            = "Postgres"

--- a/examples/data-sources/airbyte_connector_configuration/data-source.tf
+++ b/examples/data-sources/airbyte_connector_configuration/data-source.tf
@@ -61,7 +61,7 @@ data "airbyte_connector_configuration" "custom_url" {
 data "airbyte_connector_configuration" "local_spec" {
   connector_name     = "source-postgres"
   connector_version  = "3.6.28"
-  connector_registry = "./path/to/my-custom-registry.json"
+  connector_registry = "/path/to/my-custom-registry.json"
 
   configuration = {
     host     = "db.example.com"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "1.1.4"
+      version = "1.2.0"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -29,7 +29,7 @@ generation:
     skipResponseBodyAssertions: false
   telemetryEnabled: true
 terraform:
-  version: 1.1.4
+  version: 1.2.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	ossRegistryURL   = "https://connectors.airbyte.com/files/registries/v0/oss_registry.json"
-	cloudRegistryURL = "https://connectors.airbyte.com/files/registries/v0/cloud_registry.json"
+	ossRegistryURL       = "https://connectors.airbyte.com/files/registries/v0/oss_registry.json"
+	cloudRegistryURL     = "https://connectors.airbyte.com/files/registries/v0/cloud_registry.json"
+	compositeRegistryURL = "https://connectors.airbyte.com/files/registries/v0/composite_registry.json"
 	connectorCDNBase = "https://connectors.airbyte.com/files/metadata/airbyte"
 )
 
@@ -373,47 +374,24 @@ func validateRegistryValue(registry string) error {
 func (d *ConnectorConfigurationDataSource) resolveDefinitionID(ctx context.Context, connectorName, registry string) (string, error) {
 	dockerName := "airbyte/" + connectorName
 
-	// Determine registry search order.
-	primaryURL := cloudRegistryURL
-	secondaryURL := ossRegistryURL
-	primaryLabel := "cloud"
-	secondaryLabel := "oss"
-	if registry == "oss" {
-		primaryURL = ossRegistryURL
-		secondaryURL = cloudRegistryURL
-		primaryLabel = "oss"
-		secondaryLabel = "cloud"
+	var registryURL string
+	switch registry {
+	case "composite":
+		registryURL = compositeRegistryURL
+	case "oss":
+		registryURL = ossRegistryURL
+	default:
+		registryURL = cloudRegistryURL
 	}
 
-	primaryID, primaryErr := d.searchRegistry(ctx, primaryURL, dockerName, connectorName)
-	if primaryErr == nil && primaryID != "" {
-		return primaryID, nil
+	id, err := d.searchRegistry(ctx, registryURL, dockerName, connectorName)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve connector %q in %s registry: %w", connectorName, registry, err)
 	}
-
-	// Only fall back to the secondary registry for composite mode.
-	// Explicit "cloud" or "oss" must not silently resolve from the other registry.
-	if registry == "composite" {
-		secondaryID, secondaryErr := d.searchRegistry(ctx, secondaryURL, dockerName, connectorName)
-		if secondaryErr == nil && secondaryID != "" {
-			return secondaryID, nil
-		}
-		if primaryErr != nil || secondaryErr != nil {
-			var parts []string
-			if primaryErr != nil {
-				parts = append(parts, fmt.Sprintf("%s: %v", primaryLabel, primaryErr))
-			}
-			if secondaryErr != nil {
-				parts = append(parts, fmt.Sprintf("%s: %v", secondaryLabel, secondaryErr))
-			}
-			return "", fmt.Errorf("failed to resolve connector %q: %s", connectorName, strings.Join(parts, "; "))
-		}
-		return "", fmt.Errorf("connector %q not found in Cloud or OSS registries", connectorName)
+	if id == "" {
+		return "", fmt.Errorf("connector %q not found in %s registry", connectorName, registry)
 	}
-
-	if primaryErr != nil {
-		return "", fmt.Errorf("failed to resolve connector %q in %s registry: %v", connectorName, primaryLabel, primaryErr)
-	}
-	return "", fmt.Errorf("connector %q not found in %s registry", connectorName, primaryLabel)
+	return id, nil
 }
 
 func (d *ConnectorConfigurationDataSource) searchRegistry(ctx context.Context, registryURL, dockerName, connectorName string) (string, error) {

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -103,7 +103,7 @@ configuration into a single JSON blob suitable for passing to a resource.`,
 			},
 			"connector_registry": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or an absolute file path (starting with `/`) to override the spec source entirely.",
+				MarkdownDescription: "Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `composite` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or an absolute file path (starting with `/`) to override the spec source entirely.",
 			},
 			"configuration": schema.DynamicAttribute{
 				Required:            true,
@@ -162,7 +162,7 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 		version = data.ConnectorVersion.ValueString()
 	}
 
-	registry := "cloud_and_oss"
+	registry := "composite"
 	if !data.ConnectorRegistry.IsNull() && !data.ConnectorRegistry.IsUnknown() {
 		registry = data.ConnectorRegistry.ValueString()
 	}
@@ -290,7 +290,7 @@ func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Co
 	}
 
 	// Composite: try cloud first, fall back to oss.
-	if registry == "cloud_and_oss" {
+	if registry == "composite" {
 		entry, err := d.fetchSpecFromURL(ctx, fmt.Sprintf("%s/%s/%s/cloud.json", connectorCDNBase, connectorName, version))
 		if err == nil {
 			return entry, nil
@@ -351,7 +351,7 @@ func (d *ConnectorConfigurationDataSource) readSpecFromFile(path string) (*conne
 // keyword, a URL, or a local file path.
 func validateRegistryValue(registry string) error {
 	switch registry {
-	case "cloud", "oss", "cloud_and_oss":
+	case "cloud", "oss", "composite":
 		return nil
 	}
 	if strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") {
@@ -361,7 +361,7 @@ func validateRegistryValue(registry string) error {
 		return nil
 	}
 	return fmt.Errorf(
-		"unknown connector_registry value %q: must be one of \"cloud\", \"oss\", \"cloud_and_oss\", a URL (http:// or https://), or an absolute file path (starting with /)",
+		"unknown connector_registry value %q: must be one of \"cloud\", \"oss\", \"composite\", a URL (http:// or https://), or an absolute file path (starting with /)",
 		registry,
 	)
 }

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -299,8 +299,7 @@ func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Co
 	}
 
 	// Single registry keyword ("cloud" or "oss").
-	var url string
-	url = fmt.Sprintf("%s/%s/%s/%s.json", connectorCDNBase, connectorName, version, registry)
+	url := fmt.Sprintf("%s/%s/%s/%s.json", connectorCDNBase, connectorName, version, registry)
 
 	return d.fetchSpecFromURL(ctx, url)
 }

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -103,7 +103,7 @@ configuration into a single JSON blob suitable for passing to a resource.`,
 			},
 			"connector_registry": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or a local file path (starting with `/` or `./`) to override the spec source entirely.",
+				MarkdownDescription: "Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or an absolute file path (starting with `/`) to override the spec source entirely.",
 			},
 			"configuration": schema.DynamicAttribute{
 				Required:            true,
@@ -173,7 +173,7 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 	}
 
 	isExplicitOverride := strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") ||
-		strings.HasPrefix(registry, "/") || strings.HasPrefix(registry, "./")
+		strings.HasPrefix(registry, "/")
 
 	entry, err := d.fetchVersionedMetadata(ctx, connectorName, version, registry)
 	if err != nil {
@@ -279,8 +279,8 @@ func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Co
 		version = "latest"
 	}
 
-	// Local file path override.
-	if strings.HasPrefix(registry, "/") || strings.HasPrefix(registry, "./") {
+	// Local file path override (absolute paths only).
+	if strings.HasPrefix(registry, "/") {
 		return d.readSpecFromFile(registry)
 	}
 
@@ -357,11 +357,11 @@ func validateRegistryValue(registry string) error {
 	if strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") {
 		return nil
 	}
-	if strings.HasPrefix(registry, "/") || strings.HasPrefix(registry, "./") {
+	if strings.HasPrefix(registry, "/") {
 		return nil
 	}
 	return fmt.Errorf(
-		"unknown connector_registry value %q: must be one of \"cloud\", \"oss\", \"cloud_and_oss\", a URL (http:// or https://), or a local file path (starting with / or ./)",
+		"unknown connector_registry value %q: must be one of \"cloud\", \"oss\", \"cloud_and_oss\", a URL (http:// or https://), or an absolute file path (starting with /)",
 		registry,
 	)
 }

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -386,23 +386,30 @@ func (d *ConnectorConfigurationDataSource) resolveDefinitionID(ctx context.Conte
 		return primaryID, nil
 	}
 
-	secondaryID, secondaryErr := d.searchRegistry(ctx, secondaryURL, dockerName, connectorName)
-	if secondaryErr == nil && secondaryID != "" {
-		return secondaryID, nil
+	// Only fall back to the secondary registry for composite mode.
+	// Explicit "cloud" or "oss" must not silently resolve from the other registry.
+	if registry == "composite" {
+		secondaryID, secondaryErr := d.searchRegistry(ctx, secondaryURL, dockerName, connectorName)
+		if secondaryErr == nil && secondaryID != "" {
+			return secondaryID, nil
+		}
+		if primaryErr != nil || secondaryErr != nil {
+			var parts []string
+			if primaryErr != nil {
+				parts = append(parts, fmt.Sprintf("%s: %v", primaryLabel, primaryErr))
+			}
+			if secondaryErr != nil {
+				parts = append(parts, fmt.Sprintf("%s: %v", secondaryLabel, secondaryErr))
+			}
+			return "", fmt.Errorf("failed to resolve connector %q: %s", connectorName, strings.Join(parts, "; "))
+		}
+		return "", fmt.Errorf("connector %q not found in Cloud or OSS registries", connectorName)
 	}
 
-	if primaryErr != nil || secondaryErr != nil {
-		var parts []string
-		if primaryErr != nil {
-			parts = append(parts, fmt.Sprintf("%s: %v", primaryLabel, primaryErr))
-		}
-		if secondaryErr != nil {
-			parts = append(parts, fmt.Sprintf("%s: %v", secondaryLabel, secondaryErr))
-		}
-		return "", fmt.Errorf("failed to resolve connector %q: %s", connectorName, strings.Join(parts, "; "))
+	if primaryErr != nil {
+		return "", fmt.Errorf("failed to resolve connector %q in %s registry: %v", connectorName, primaryLabel, primaryErr)
 	}
-
-	return "", fmt.Errorf("connector %q not found in Cloud or OSS registries", connectorName)
+	return "", fmt.Errorf("connector %q not found in %s registry", connectorName, primaryLabel)
 }
 
 func (d *ConnectorConfigurationDataSource) searchRegistry(ctx context.Context, registryURL, dockerName, connectorName string) (string, error) {

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -37,6 +38,7 @@ type ConnectorConfigurationDataSource struct {
 type ConnectorConfigurationDataSourceModel struct {
 	ConnectorName        types.String  `tfsdk:"connector_name"`
 	ConnectorVersion     types.String  `tfsdk:"connector_version"`
+	SpecSource           types.String  `tfsdk:"spec_source"`
 	Configuration        types.Dynamic `tfsdk:"configuration"`
 	ConfigurationSecrets types.Dynamic `tfsdk:"configuration_secrets"`
 	IgnoreErrors         types.Bool    `tfsdk:"ignore_errors"`
@@ -99,6 +101,10 @@ configuration into a single JSON blob suitable for passing to a resource.`,
 				Optional:            true,
 				MarkdownDescription: "The version of the connector (e.g. `2.0.0`). If not specified, the latest version is used. When set, the connector spec for that exact version is fetched and used for JSONSchema validation.",
 			},
+			"spec_source": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Controls where the connector spec is fetched from. Accepted values: `cloud` (default) fetches from the Cloud registry, `oss` fetches from the OSS registry. You can also provide a full URL (starting with `http://` or `https://`) or a local file path to override the spec source entirely.",
+			},
 			"configuration": schema.DynamicAttribute{
 				Required:            true,
 				MarkdownDescription: "Non-sensitive configuration values as an HCL object. These will be visible in Terraform plan output.",
@@ -156,7 +162,12 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 		version = data.ConnectorVersion.ValueString()
 	}
 
-	entry, err := d.fetchVersionedMetadata(ctx, connectorName, version)
+	specSource := "cloud"
+	if !data.SpecSource.IsNull() && !data.SpecSource.IsUnknown() {
+		specSource = data.SpecSource.ValueString()
+	}
+
+	entry, err := d.fetchVersionedMetadata(ctx, connectorName, version, specSource)
 	if err != nil {
 		if version != "" {
 			resp.Diagnostics.AddWarning(
@@ -164,7 +175,7 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 				fmt.Sprintf("Failed to fetch spec for %s version %q: %v. Falling back to registry lookup without version pinning or JSONSchema validation.", connectorName, version, err),
 			)
 		}
-		definitionID, fallbackErr := d.resolveDefinitionID(ctx, connectorName)
+		definitionID, fallbackErr := d.resolveDefinitionID(ctx, connectorName, specSource)
 		if fallbackErr != nil {
 			addDiagnostic(resp, ignoreErrors, "Failed to resolve connector", fmt.Sprintf(
 				"Versioned endpoint: %v\nRegistry fallback: %v", err, fallbackErr,
@@ -247,12 +258,23 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Context, connectorName, version string) (*connectorVersionedEntry, error) {
+func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Context, connectorName, version, specSource string) (*connectorVersionedEntry, error) {
 	if version == "" {
 		version = "latest"
 	}
 
-	url := fmt.Sprintf("%s/%s/%s/cloud.json", connectorCDNBase, connectorName, version)
+	// If specSource is a local file path, read from disk.
+	if specSource != "cloud" && specSource != "oss" && !strings.HasPrefix(specSource, "http://") && !strings.HasPrefix(specSource, "https://") {
+		return d.readSpecFromFile(specSource)
+	}
+
+	var url string
+	if strings.HasPrefix(specSource, "http://") || strings.HasPrefix(specSource, "https://") {
+		url = specSource
+	} else {
+		// specSource is "cloud" or "oss"
+		url = fmt.Sprintf("%s/%s/%s/%s.json", connectorCDNBase, connectorName, version, specSource)
+	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -282,26 +304,52 @@ func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Co
 	return &entry, nil
 }
 
-func (d *ConnectorConfigurationDataSource) resolveDefinitionID(ctx context.Context, connectorName string) (string, error) {
+func (d *ConnectorConfigurationDataSource) readSpecFromFile(path string) (*connectorVersionedEntry, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read spec from file %s: %w", path, err)
+	}
+
+	var entry connectorVersionedEntry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return nil, fmt.Errorf("failed to parse spec JSON from file %s: %w", path, err)
+	}
+
+	return &entry, nil
+}
+
+func (d *ConnectorConfigurationDataSource) resolveDefinitionID(ctx context.Context, connectorName, specSource string) (string, error) {
 	dockerName := "airbyte/" + connectorName
 
-	cloudID, cloudErr := d.searchRegistry(ctx, cloudRegistryURL, dockerName, connectorName)
-	if cloudErr == nil && cloudID != "" {
-		return cloudID, nil
+	// Determine registry search order based on specSource.
+	primaryURL := cloudRegistryURL
+	secondaryURL := ossRegistryURL
+	primaryLabel := "cloud"
+	secondaryLabel := "oss"
+	if specSource == "oss" {
+		primaryURL = ossRegistryURL
+		secondaryURL = cloudRegistryURL
+		primaryLabel = "oss"
+		secondaryLabel = "cloud"
 	}
 
-	ossID, ossErr := d.searchRegistry(ctx, ossRegistryURL, dockerName, connectorName)
-	if ossErr == nil && ossID != "" {
-		return ossID, nil
+	primaryID, primaryErr := d.searchRegistry(ctx, primaryURL, dockerName, connectorName)
+	if primaryErr == nil && primaryID != "" {
+		return primaryID, nil
 	}
 
-	if cloudErr != nil || ossErr != nil {
+	secondaryID, secondaryErr := d.searchRegistry(ctx, secondaryURL, dockerName, connectorName)
+	if secondaryErr == nil && secondaryID != "" {
+		return secondaryID, nil
+	}
+
+	if primaryErr != nil || secondaryErr != nil {
 		var parts []string
-		if cloudErr != nil {
-			parts = append(parts, fmt.Sprintf("cloud: %v", cloudErr))
+		if primaryErr != nil {
+			parts = append(parts, fmt.Sprintf("%s: %v", primaryLabel, primaryErr))
 		}
-		if ossErr != nil {
-			parts = append(parts, fmt.Sprintf("oss: %v", ossErr))
+		if secondaryErr != nil {
+			parts = append(parts, fmt.Sprintf("%s: %v", secondaryLabel, secondaryErr))
 		}
 		return "", fmt.Errorf("failed to resolve connector %q: %s", connectorName, strings.Join(parts, "; "))
 	}

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -38,7 +38,7 @@ type ConnectorConfigurationDataSource struct {
 type ConnectorConfigurationDataSourceModel struct {
 	ConnectorName        types.String  `tfsdk:"connector_name"`
 	ConnectorVersion     types.String  `tfsdk:"connector_version"`
-	SpecSource           types.String  `tfsdk:"spec_source"`
+	ConnectorRegistry    types.String  `tfsdk:"connector_registry"`
 	Configuration        types.Dynamic `tfsdk:"configuration"`
 	ConfigurationSecrets types.Dynamic `tfsdk:"configuration_secrets"`
 	IgnoreErrors         types.Bool    `tfsdk:"ignore_errors"`
@@ -101,9 +101,9 @@ configuration into a single JSON blob suitable for passing to a resource.`,
 				Optional:            true,
 				MarkdownDescription: "The version of the connector (e.g. `2.0.0`). If not specified, the latest version is used. When set, the connector spec for that exact version is fetched and used for JSONSchema validation.",
 			},
-			"spec_source": schema.StringAttribute{
+			"connector_registry": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Controls where the connector spec is fetched from. Accepted values: `cloud` (default) fetches from the Cloud registry, `oss` fetches from the OSS registry. You can also provide a full URL (starting with `http://` or `https://`) or a local file path to override the spec source entirely.",
+				MarkdownDescription: "Controls where the connector spec is fetched from. Accepted values: `cloud` fetches from the Cloud registry, `oss` fetches from the OSS registry, and `cloud_and_oss` (default) tries Cloud first then falls back to OSS. You can also provide a full URL (starting with `http://` or `https://`) or a local file path (starting with `/` or `./`) to override the spec source entirely.",
 			},
 			"configuration": schema.DynamicAttribute{
 				Required:            true,
@@ -162,20 +162,36 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 		version = data.ConnectorVersion.ValueString()
 	}
 
-	specSource := "cloud"
-	if !data.SpecSource.IsNull() && !data.SpecSource.IsUnknown() {
-		specSource = data.SpecSource.ValueString()
+	registry := "cloud_and_oss"
+	if !data.ConnectorRegistry.IsNull() && !data.ConnectorRegistry.IsUnknown() {
+		registry = data.ConnectorRegistry.ValueString()
 	}
 
-	entry, err := d.fetchVersionedMetadata(ctx, connectorName, version, specSource)
+	if err := validateRegistryValue(registry); err != nil {
+		resp.Diagnostics.AddError("Invalid connector_registry value", err.Error())
+		return
+	}
+
+	isExplicitOverride := strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") ||
+		strings.HasPrefix(registry, "/") || strings.HasPrefix(registry, "./")
+
+	entry, err := d.fetchVersionedMetadata(ctx, connectorName, version, registry)
 	if err != nil {
-		if version != "" {
+		if isExplicitOverride {
+			addDiagnostic(resp, ignoreErrors, "Failed to fetch spec from connector_registry override", fmt.Sprintf(
+				"connector_registry=%q: %v", registry, err,
+			))
+			if !ignoreErrors {
+				return
+			}
+		}
+		if version != "" && !isExplicitOverride {
 			resp.Diagnostics.AddWarning(
 				"Could not fetch versioned connector metadata",
 				fmt.Sprintf("Failed to fetch spec for %s version %q: %v. Falling back to registry lookup without version pinning or JSONSchema validation.", connectorName, version, err),
 			)
 		}
-		definitionID, fallbackErr := d.resolveDefinitionID(ctx, connectorName, specSource)
+		definitionID, fallbackErr := d.resolveDefinitionID(ctx, connectorName, registry)
 		if fallbackErr != nil {
 			addDiagnostic(resp, ignoreErrors, "Failed to resolve connector", fmt.Sprintf(
 				"Versioned endpoint: %v\nRegistry fallback: %v", err, fallbackErr,
@@ -258,24 +274,38 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Context, connectorName, version, specSource string) (*connectorVersionedEntry, error) {
+func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Context, connectorName, version, registry string) (*connectorVersionedEntry, error) {
 	if version == "" {
 		version = "latest"
 	}
 
-	// If specSource is a local file path, read from disk.
-	if specSource != "cloud" && specSource != "oss" && !strings.HasPrefix(specSource, "http://") && !strings.HasPrefix(specSource, "https://") {
-		return d.readSpecFromFile(specSource)
+	// Local file path override.
+	if strings.HasPrefix(registry, "/") || strings.HasPrefix(registry, "./") {
+		return d.readSpecFromFile(registry)
 	}
 
+	// URL override.
+	if strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") {
+		return d.fetchSpecFromURL(ctx, registry)
+	}
+
+	// Composite: try cloud first, fall back to oss.
+	if registry == "cloud_and_oss" {
+		entry, err := d.fetchSpecFromURL(ctx, fmt.Sprintf("%s/%s/%s/cloud.json", connectorCDNBase, connectorName, version))
+		if err == nil {
+			return entry, nil
+		}
+		return d.fetchSpecFromURL(ctx, fmt.Sprintf("%s/%s/%s/oss.json", connectorCDNBase, connectorName, version))
+	}
+
+	// Single registry keyword ("cloud" or "oss").
 	var url string
-	if strings.HasPrefix(specSource, "http://") || strings.HasPrefix(specSource, "https://") {
-		url = specSource
-	} else {
-		// specSource is "cloud" or "oss"
-		url = fmt.Sprintf("%s/%s/%s/%s.json", connectorCDNBase, connectorName, version, specSource)
-	}
+	url = fmt.Sprintf("%s/%s/%s/%s.json", connectorCDNBase, connectorName, version, registry)
 
+	return d.fetchSpecFromURL(ctx, url)
+}
+
+func (d *ConnectorConfigurationDataSource) fetchSpecFromURL(ctx context.Context, url string) (*connectorVersionedEntry, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %s: %w", url, err)
@@ -307,26 +337,45 @@ func (d *ConnectorConfigurationDataSource) fetchVersionedMetadata(ctx context.Co
 func (d *ConnectorConfigurationDataSource) readSpecFromFile(path string) (*connectorVersionedEntry, error) {
 	body, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read spec from file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to read spec from file %q: %w", path, err)
 	}
 
 	var entry connectorVersionedEntry
 	if err := json.Unmarshal(body, &entry); err != nil {
-		return nil, fmt.Errorf("failed to parse spec JSON from file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to parse spec JSON from file %q: %w", path, err)
 	}
 
 	return &entry, nil
 }
 
-func (d *ConnectorConfigurationDataSource) resolveDefinitionID(ctx context.Context, connectorName, specSource string) (string, error) {
+// validateRegistryValue checks that the connector_registry value is a known
+// keyword, a URL, or a local file path.
+func validateRegistryValue(registry string) error {
+	switch registry {
+	case "cloud", "oss", "cloud_and_oss":
+		return nil
+	}
+	if strings.HasPrefix(registry, "http://") || strings.HasPrefix(registry, "https://") {
+		return nil
+	}
+	if strings.HasPrefix(registry, "/") || strings.HasPrefix(registry, "./") {
+		return nil
+	}
+	return fmt.Errorf(
+		"unknown connector_registry value %q: must be one of \"cloud\", \"oss\", \"cloud_and_oss\", a URL (http:// or https://), or a local file path (starting with / or ./)",
+		registry,
+	)
+}
+
+func (d *ConnectorConfigurationDataSource) resolveDefinitionID(ctx context.Context, connectorName, registry string) (string, error) {
 	dockerName := "airbyte/" + connectorName
 
-	// Determine registry search order based on specSource.
+	// Determine registry search order.
 	primaryURL := cloudRegistryURL
 	secondaryURL := ossRegistryURL
 	primaryLabel := "cloud"
 	secondaryLabel := "oss"
-	if specSource == "oss" {
+	if registry == "oss" {
 		primaryURL = ossRegistryURL
 		secondaryURL = cloudRegistryURL
 		primaryLabel = "oss"

--- a/internal/provider/connector_configuration_data_source.go
+++ b/internal/provider/connector_configuration_data_source.go
@@ -185,22 +185,26 @@ func (d *ConnectorConfigurationDataSource) Read(ctx context.Context, req datasou
 				return
 			}
 		}
-		if version != "" && !isExplicitOverride {
-			resp.Diagnostics.AddWarning(
-				"Could not fetch versioned connector metadata",
-				fmt.Sprintf("Failed to fetch spec for %s version %q: %v. Falling back to registry lookup without version pinning or JSONSchema validation.", connectorName, version, err),
-			)
-		}
-		definitionID, fallbackErr := d.resolveDefinitionID(ctx, connectorName, registry)
-		if fallbackErr != nil {
-			addDiagnostic(resp, ignoreErrors, "Failed to resolve connector", fmt.Sprintf(
-				"Versioned endpoint: %v\nRegistry fallback: %v", err, fallbackErr,
-			))
-			if !ignoreErrors {
-				return
+		// Only fall back to registry lookup for keyword modes (cloud, oss, composite).
+		// Explicit URL/file overrides must not silently resolve from a different registry.
+		if !isExplicitOverride {
+			if version != "" {
+				resp.Diagnostics.AddWarning(
+					"Could not fetch versioned connector metadata",
+					fmt.Sprintf("Failed to fetch spec for %s version %q: %v. Falling back to registry lookup without version pinning or JSONSchema validation.", connectorName, version, err),
+				)
 			}
-		} else {
-			data.DefinitionID = types.StringValue(definitionID)
+			definitionID, fallbackErr := d.resolveDefinitionID(ctx, connectorName, registry)
+			if fallbackErr != nil {
+				addDiagnostic(resp, ignoreErrors, "Failed to resolve connector", fmt.Sprintf(
+					"Versioned endpoint: %v\nRegistry fallback: %v", err, fallbackErr,
+				))
+				if !ignoreErrors {
+					return
+				}
+			} else {
+				data.DefinitionID = types.StringValue(definitionID)
+			}
 		}
 	} else {
 		if strings.HasPrefix(connectorName, "source-") {

--- a/internal/provider/connector_configuration_data_source_test.go
+++ b/internal/provider/connector_configuration_data_source_test.go
@@ -169,7 +169,28 @@ func TestFetchVersionedMetadata_HTTPError(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
-func TestFetchVersionedMetadata_OSSSpecSource(t *testing.T) {
+func TestValidateRegistryValue(t *testing.T) {
+	// Valid keywords.
+	assert.NoError(t, validateRegistryValue("cloud"))
+	assert.NoError(t, validateRegistryValue("oss"))
+	assert.NoError(t, validateRegistryValue("cloud_and_oss"))
+
+	// Valid URLs.
+	assert.NoError(t, validateRegistryValue("https://example.com/spec.json"))
+	assert.NoError(t, validateRegistryValue("http://localhost:8080/spec.json"))
+
+	// Valid file paths.
+	assert.NoError(t, validateRegistryValue("/absolute/path/spec.json"))
+	assert.NoError(t, validateRegistryValue("./relative/path/spec.json"))
+
+	// Invalid values.
+	assert.Error(t, validateRegistryValue("bogus"))
+	assert.Error(t, validateRegistryValue("Cloud"))
+	assert.Error(t, validateRegistryValue("relative/path/spec.json"))
+	assert.Error(t, validateRegistryValue(""))
+}
+
+func TestFetchVersionedMetadata_OSSRegistry(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/files/metadata/airbyte/source-postgres/3.6.28/oss.json", r.URL.Path)
 		resp := map[string]interface{}{
@@ -250,7 +271,8 @@ func TestFetchVersionedMetadata_FileOverride(t *testing.T) {
 			}
 		}
 	}`
-	tmpFile := t.TempDir() + "/spec.json"
+	tmpDir := t.TempDir()
+	tmpFile := tmpDir + "/spec.json"
 	err := os.WriteFile(tmpFile, []byte(specJSON), 0644)
 	require.NoError(t, err)
 
@@ -258,6 +280,7 @@ func TestFetchVersionedMetadata_FileOverride(t *testing.T) {
 		httpClient: &http.Client{Timeout: 5 * time.Second},
 	}
 
+	// Absolute path (starts with /).
 	ctx := context.Background()
 	entry, err := ds.fetchVersionedMetadata(ctx, "source-file", "2.0.0", tmpFile)
 	require.NoError(t, err)
@@ -275,6 +298,45 @@ func TestFetchVersionedMetadata_FileNotFound(t *testing.T) {
 	_, err := ds.fetchVersionedMetadata(ctx, "source-test", "1.0.0", "/nonexistent/path/spec.json")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read spec from file")
+}
+
+func TestFetchSpecFromURL_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"sourceDefinitionId": "url-def-id",
+			"dockerRepository":   "airbyte/source-test",
+			"dockerImageTag":     "1.0.0",
+			"name":               "Test",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ds := &ConnectorConfigurationDataSource{
+		httpClient: server.Client(),
+	}
+
+	ctx := context.Background()
+	entry, err := ds.fetchSpecFromURL(ctx, server.URL+"/spec.json")
+	require.NoError(t, err)
+	assert.Equal(t, "url-def-id", entry.SourceDefinitionID)
+}
+
+func TestFetchSpecFromURL_Fallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ds := &ConnectorConfigurationDataSource{
+		httpClient: server.Client(),
+	}
+
+	ctx := context.Background()
+	_, err := ds.fetchSpecFromURL(ctx, server.URL+"/missing.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
 }
 
 func TestCollectValidationErrors(t *testing.T) {

--- a/internal/provider/connector_configuration_data_source_test.go
+++ b/internal/provider/connector_configuration_data_source_test.go
@@ -179,13 +179,13 @@ func TestValidateRegistryValue(t *testing.T) {
 	assert.NoError(t, validateRegistryValue("https://example.com/spec.json"))
 	assert.NoError(t, validateRegistryValue("http://localhost:8080/spec.json"))
 
-	// Valid file paths.
+	// Valid file paths (absolute only).
 	assert.NoError(t, validateRegistryValue("/absolute/path/spec.json"))
-	assert.NoError(t, validateRegistryValue("./relative/path/spec.json"))
 
 	// Invalid values.
 	assert.Error(t, validateRegistryValue("bogus"))
 	assert.Error(t, validateRegistryValue("Cloud"))
+	assert.Error(t, validateRegistryValue("./relative/path/spec.json"))
 	assert.Error(t, validateRegistryValue("relative/path/spec.json"))
 	assert.Error(t, validateRegistryValue(""))
 }

--- a/internal/provider/connector_configuration_data_source_test.go
+++ b/internal/provider/connector_configuration_data_source_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -166,6 +167,114 @@ func TestFetchVersionedMetadata_HTTPError(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestFetchVersionedMetadata_OSSSpecSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/files/metadata/airbyte/source-postgres/3.6.28/oss.json", r.URL.Path)
+		resp := map[string]interface{}{
+			"sourceDefinitionId": "oss-def-id-456",
+			"dockerRepository":   "airbyte/source-postgres",
+			"dockerImageTag":     "3.6.28",
+			"name":               "Postgres",
+			"spec": map[string]interface{}{
+				"connectionSpecification": map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/files/metadata/airbyte/source-postgres/3.6.28/oss.json", nil)
+	require.NoError(t, err)
+
+	client := server.Client()
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	var entry connectorVersionedEntry
+	err = json.NewDecoder(resp.Body).Decode(&entry)
+	require.NoError(t, err)
+	assert.Equal(t, "oss-def-id-456", entry.SourceDefinitionID)
+	assert.Equal(t, "3.6.28", entry.DockerImageTag)
+	assert.NotNil(t, entry.Spec)
+}
+
+func TestFetchVersionedMetadata_URLOverride(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/custom/spec.json", r.URL.Path)
+		resp := map[string]interface{}{
+			"sourceDefinitionId": "custom-def-id-789",
+			"dockerRepository":   "airbyte/source-custom",
+			"dockerImageTag":     "1.0.0",
+			"name":               "Custom",
+			"spec": map[string]interface{}{
+				"connectionSpecification": map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ds := &ConnectorConfigurationDataSource{
+		httpClient: server.Client(),
+	}
+
+	ctx := context.Background()
+	entry, err := ds.fetchVersionedMetadata(ctx, "source-custom", "1.0.0", server.URL+"/custom/spec.json")
+	require.NoError(t, err)
+	assert.Equal(t, "custom-def-id-789", entry.SourceDefinitionID)
+	assert.Equal(t, "1.0.0", entry.DockerImageTag)
+}
+
+func TestFetchVersionedMetadata_FileOverride(t *testing.T) {
+	specJSON := `{
+		"sourceDefinitionId": "file-def-id-321",
+		"dockerRepository": "airbyte/source-file",
+		"dockerImageTag": "2.0.0",
+		"name": "File Source",
+		"spec": {
+			"connectionSpecification": {
+				"type": "object",
+				"properties": {}
+			}
+		}
+	}`
+	tmpFile := t.TempDir() + "/spec.json"
+	err := os.WriteFile(tmpFile, []byte(specJSON), 0644)
+	require.NoError(t, err)
+
+	ds := &ConnectorConfigurationDataSource{
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx := context.Background()
+	entry, err := ds.fetchVersionedMetadata(ctx, "source-file", "2.0.0", tmpFile)
+	require.NoError(t, err)
+	assert.Equal(t, "file-def-id-321", entry.SourceDefinitionID)
+	assert.Equal(t, "2.0.0", entry.DockerImageTag)
+	assert.NotNil(t, entry.Spec)
+}
+
+func TestFetchVersionedMetadata_FileNotFound(t *testing.T) {
+	ds := &ConnectorConfigurationDataSource{
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx := context.Background()
+	_, err := ds.fetchVersionedMetadata(ctx, "source-test", "1.0.0", "/nonexistent/path/spec.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read spec from file")
 }
 
 func TestCollectValidationErrors(t *testing.T) {

--- a/internal/provider/connector_configuration_data_source_test.go
+++ b/internal/provider/connector_configuration_data_source_test.go
@@ -173,7 +173,7 @@ func TestValidateRegistryValue(t *testing.T) {
 	// Valid keywords.
 	assert.NoError(t, validateRegistryValue("cloud"))
 	assert.NoError(t, validateRegistryValue("oss"))
-	assert.NoError(t, validateRegistryValue("cloud_and_oss"))
+	assert.NoError(t, validateRegistryValue("composite"))
 
 	// Valid URLs.
 	assert.NoError(t, validateRegistryValue("https://example.com/spec.json"))

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -150,9 +150,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *SDK {
 	sdk := &SDK{
-		SDKVersion: "1.1.4",
+		SDKVersion: "1.2.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.1.4 2.881.17 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.2.0 2.881.17 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/templates/data-sources/connector_configuration.md.tmpl
+++ b/templates/data-sources/connector_configuration.md.tmpl
@@ -61,16 +61,16 @@ data "airbyte_connector_configuration" "postgres" {
 }
 ```
 
-### Override the spec source (OSS, URL, or local file)
+### Override the connector registry
 
-By default, the spec is fetched from the **Cloud** registry. Use `spec_source` to switch to **OSS**, a custom **URL**, or a **local file**:
+By default, the spec is fetched from both **Cloud** and **OSS** registries (composite). Use `connector_registry` to target a specific registry, a custom **URL**, or a **local file**. URLs and file paths must serve well-formatted registry JSON:
 
 ```terraform
-# Use the OSS registry
+# Use the OSS registry only
 data "airbyte_connector_configuration" "postgres_oss" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "oss"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "oss"
 
   configuration = {
     host     = "db.example.com"
@@ -81,9 +81,9 @@ data "airbyte_connector_configuration" "postgres_oss" {
 
 # Use a custom URL
 data "airbyte_connector_configuration" "custom_url" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "https://example.com/my-custom-spec.json"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "https://example.com/my-registry-spec.json"
 
   configuration = {
     host     = "db.example.com"
@@ -94,9 +94,9 @@ data "airbyte_connector_configuration" "custom_url" {
 
 # Use a local file
 data "airbyte_connector_configuration" "local_spec" {
-  connector_name    = "source-postgres"
-  connector_version = "3.6.28"
-  spec_source       = "./specs/source-postgres.json"
+  connector_name     = "source-postgres"
+  connector_version  = "3.6.28"
+  connector_registry = "./specs/source-postgres.json"
 
   configuration = {
     host     = "db.example.com"

--- a/templates/data-sources/connector_configuration.md.tmpl
+++ b/templates/data-sources/connector_configuration.md.tmpl
@@ -96,7 +96,7 @@ data "airbyte_connector_configuration" "custom_url" {
 data "airbyte_connector_configuration" "local_spec" {
   connector_name     = "source-postgres"
   connector_version  = "3.6.28"
-  connector_registry = "./specs/source-postgres.json"
+  connector_registry = "./path/to/my-custom-registry.json"
 
   configuration = {
     host     = "db.example.com"

--- a/templates/data-sources/connector_configuration.md.tmpl
+++ b/templates/data-sources/connector_configuration.md.tmpl
@@ -61,6 +61,51 @@ data "airbyte_connector_configuration" "postgres" {
 }
 ```
 
+### Override the spec source (OSS, URL, or local file)
+
+By default, the spec is fetched from the **Cloud** registry. Use `spec_source` to switch to **OSS**, a custom **URL**, or a **local file**:
+
+```terraform
+# Use the OSS registry
+data "airbyte_connector_configuration" "postgres_oss" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "oss"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+
+# Use a custom URL
+data "airbyte_connector_configuration" "custom_url" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "https://example.com/my-custom-spec.json"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+
+# Use a local file
+data "airbyte_connector_configuration" "local_spec" {
+  connector_name    = "source-postgres"
+  connector_version = "3.6.28"
+  spec_source       = "./specs/source-postgres.json"
+
+  configuration = {
+    host     = "db.example.com"
+    port     = 5432
+    database = "mydb"
+  }
+}
+```
+
 ### Pass resolved values to a resource
 
 Use the data source outputs to configure an [`airbyte_source`](../resources/source.md) or [`airbyte_destination`](../resources/destination.md) resource:

--- a/templates/data-sources/connector_configuration.md.tmpl
+++ b/templates/data-sources/connector_configuration.md.tmpl
@@ -96,7 +96,7 @@ data "airbyte_connector_configuration" "custom_url" {
 data "airbyte_connector_configuration" "local_spec" {
   connector_name     = "source-postgres"
   connector_version  = "3.6.28"
-  connector_registry = "./path/to/my-custom-registry.json"
+  connector_registry = "/path/to/my-custom-registry.json"
 
   configuration = {
     host     = "db.example.com"


### PR DESCRIPTION
## Summary

Closes #340

Adds a new optional `connector_registry` attribute to the `airbyte_connector_configuration` data source that lets users control where the connector spec is fetched from.

**Accepted values:**
- `composite` (default) — tries Cloud registry first, falls back to OSS
- `cloud` — Cloud registry only
- `oss` — OSS registry only
- `https://...` or `http://...` — custom URL (must serve well-formatted registry JSON)
- `/path/...` — absolute file path (must contain well-formatted registry JSON)

Any other value is rejected with a clear validation error.

**Key implementation details:**
- `validateRegistryValue()` validates the attribute upfront
- `fetchSpecFromURL()` extracted as shared helper
- Explicit URL/file overrides error on failure (no silent fallback to CDN or cloud registry)
- `resolveDefinitionID()` respects registry preference — only `composite` mode searches both registries; explicit `cloud` or `oss` restricts to that single registry

## Review & Testing Checklist for Human

- [x] Verify `connector_registry = "oss"` fetches from the `oss.json` CDN endpoint
- [x] Verify default behavior (no `connector_registry` set) tries cloud then falls back to oss (`composite`)
- [x] Verify invalid values (e.g. `"bogus"`) produce a clear error
- [x] Test with an absolute file path to confirm it reads well-formatted registry JSON
- [x] Confirm the generated docs at `docs/data-sources/connector_configuration.md` render correctly

All E2E tests passed — see [test results comment](https://github.com/airbytehq/terraform-provider-airbyte/pull/430#issuecomment-4191905067) for details.

### Notes

- The "Zero-Diff Check (Generated Code)" CI failure is pre-existing drift in `internal/sdk/sdk.go` and `docs/index.md` — files not touched by this PR.
- All unit tests pass locally (`go test ./internal/provider/ -v`).
- `connector_configuration_data_source.go` and its test file are custom (not Speakeasy-generated), so hand-editing is appropriate per AGENTS.md.

Link to Devin session: https://app.devin.ai/sessions/7c5c69bc85304434aa4748ce9989dca2
Requested by: @aaronsteers