### PR TITLE
feat(connection): Support cron time zones via config API

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -171,6 +171,7 @@ Read-Only:
 
 - `basic_timing` (String)
 - `cron_expression` (String)
+- `cron_time_zone` (String)
 - `schedule_type` (String)
 
 

--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -171,7 +171,6 @@ Read-Only:
 
 - `basic_timing` (String)
 - `cron_expression` (String)
-- `cron_time_zone` (String)
 - `schedule_type` (String)
 
 

--- a/docs/data-sources/connections.md
+++ b/docs/data-sources/connections.md
@@ -193,6 +193,7 @@ Read-Only:
 
 - `basic_timing` (String)
 - `cron_expression` (String)
+- `cron_time_zone` (String)
 - `schedule_type` (String)
 
 

--- a/docs/data-sources/connections.md
+++ b/docs/data-sources/connections.md
@@ -193,7 +193,6 @@ Read-Only:
 
 - `basic_timing` (String)
 - `cron_expression` (String)
-- `cron_time_zone` (String)
 - `schedule_type` (String)
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "1.2.1"
+      version = "1.3.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "1.3.0"
+      version = "1.2.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ provider "airbyte" {
 - `bearer_auth` (String, Sensitive) HTTP Bearer.
 - `client_id` (String, Sensitive) OAuth2 Client Credentials Flow client identifier.
 - `client_secret` (String, Sensitive) OAuth2 Client Credentials Flow client secret.
+- `config_api_root` (String) Internal config API root used for connection schedule features not exposed by the public API (defaults to the corresponding Airbyte config API for server_url).
 - `password` (String, Sensitive) HTTP Basic password.
 - `server_url` (String) Server URL (defaults to https://api.airbyte.com/v1)
 - `token_url` (String, Sensitive) OAuth2 Client Credentials Flow token URL.

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -238,6 +238,7 @@ Optional:
 Optional:
 
 - `cron_expression` (String)
+- `cron_time_zone` (String) IANA time zone used to evaluate cron schedules, for example "America/New_York". Defaults to Airbyte's API default when omitted.
 - `schedule_type` (String) Not Null; must be one of ["manual", "cron"]
 
 Read-Only:

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "1.2.1"
+      version = "1.3.0"
     }
   }
 }

--- a/internal/provider/connection_cron_timezone.go
+++ b/internal/provider/connection_cron_timezone.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	tfTypes "github.com/airbytehq/terraform-provider-airbyte/internal/provider/types"
-	"github.com/airbytehq/terraform-provider-airbyte/internal/sdk"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -20,18 +19,6 @@ import (
 type providerRuntimeConfig struct {
 	ConfigAPIRoot string
 	HTTPClient    *http.Client
-}
-
-type configuredProviderData struct {
-	Client        *sdk.SDK
-	RuntimeConfig providerRuntimeConfig
-}
-
-func connectionResourceProviderData(data any) (*sdk.SDK, providerRuntimeConfig, bool) {
-	if data, ok := data.(*configuredProviderData); ok && data.Client != nil {
-		return data.Client, data.RuntimeConfig, true
-	}
-	return nil, providerRuntimeConfig{}, false
 }
 
 func deriveConfigAPIRoot(publicAPIRoot string) string {

--- a/internal/provider/connection_cron_timezone.go
+++ b/internal/provider/connection_cron_timezone.go
@@ -1,0 +1,282 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	tfTypes "github.com/airbytehq/terraform-provider-airbyte/internal/provider/types"
+	"github.com/airbytehq/terraform-provider-airbyte/internal/sdk"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type providerRuntimeConfig struct {
+	ConfigAPIRoot string
+}
+
+var providerRuntimeConfigs sync.Map
+
+func storeProviderRuntimeConfig(client *sdk.SDK, config providerRuntimeConfig) {
+	providerRuntimeConfigs.Store(client, config)
+}
+
+func getProviderRuntimeConfig(client *sdk.SDK) providerRuntimeConfig {
+	if config, ok := providerRuntimeConfigs.Load(client); ok {
+		return config.(providerRuntimeConfig)
+	}
+	return providerRuntimeConfig{}
+}
+
+func deriveConfigAPIRoot(publicAPIRoot string) string {
+	publicAPIRoot = strings.TrimRight(publicAPIRoot, "/")
+	if strings.Contains(publicAPIRoot, "api.airbyte.com") {
+		return "https://cloud.airbyte.com/api"
+	}
+	if strings.HasSuffix(publicAPIRoot, "/api/public/v1") {
+		return strings.TrimSuffix(publicAPIRoot, "/public/v1")
+	}
+	if strings.HasSuffix(publicAPIRoot, "/api/v1") {
+		return strings.TrimSuffix(publicAPIRoot, "/v1")
+	}
+	return strings.TrimSuffix(publicAPIRoot, "/v1")
+}
+
+func stripCronTimeZone(cronExpression string) (string, string) {
+	fields := strings.Fields(cronExpression)
+	if len(fields) <= 6 {
+		return cronExpression, ""
+	}
+
+	last := fields[len(fields)-1]
+	if _, err := time.LoadLocation(last); err != nil {
+		return cronExpression, ""
+	}
+
+	return strings.Join(fields[:len(fields)-1], " "), last
+}
+
+func stringPointerValue(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func cronScheduleParts(schedule *tfTypes.AirbyteAPIConnectionSchedule) (string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if schedule == nil || schedule.ScheduleType.ValueString() != "cron" {
+		return "", "", diags
+	}
+
+	cronExpression := schedule.CronExpression.ValueString()
+	if cronExpression == "" {
+		return "", "", diags
+	}
+
+	cleanCronExpression, suffixTimeZone := stripCronTimeZone(cronExpression)
+	cronTimeZone := suffixTimeZone
+	if !schedule.CronTimeZone.IsUnknown() && !schedule.CronTimeZone.IsNull() && schedule.CronTimeZone.ValueString() != "" {
+		cronTimeZone = schedule.CronTimeZone.ValueString()
+	}
+	if cronTimeZone == "" {
+		return cleanCronExpression, "", diags
+	}
+
+	if _, err := time.LoadLocation(cronTimeZone); err != nil {
+		diags.AddError("Invalid cron time zone", fmt.Sprintf("cron_time_zone must be a valid IANA time zone: %s", err))
+		return "", "", diags
+	}
+
+	return cleanCronExpression, cronTimeZone, diags
+}
+
+func cronExpressionForPublicAPI(schedule *tfTypes.AirbyteAPIConnectionSchedule) *string {
+	if schedule == nil || schedule.CronExpression.IsUnknown() || schedule.CronExpression.IsNull() {
+		return nil
+	}
+	cronExpression, _ := stripCronTimeZone(schedule.CronExpression.ValueString())
+	return stringPointerValue(cronExpression)
+}
+
+func applyCronScheduleResponse(schedule *tfTypes.AirbyteAPIConnectionSchedule, cronExpression *string, cronTimeZone *string) {
+	if schedule == nil {
+		return
+	}
+
+	if cronExpression == nil {
+		schedule.CronExpression = types.StringNull()
+		schedule.CronTimeZone = types.StringPointerValue(cronTimeZone)
+		return
+	}
+
+	cleanCronExpression, suffixTimeZone := stripCronTimeZone(*cronExpression)
+	if cronTimeZone == nil && suffixTimeZone != "" {
+		cronTimeZone = &suffixTimeZone
+	}
+
+	schedule.CronExpression = types.StringValue(cleanCronExpression)
+	schedule.CronTimeZone = types.StringPointerValue(cronTimeZone)
+}
+
+func applyCronScheduleDataSourceResponse(schedule *tfTypes.ConnectionScheduleResponse, cronExpression *string, cronTimeZone *string) {
+	if schedule == nil {
+		return
+	}
+
+	if cronExpression == nil {
+		schedule.CronExpression = types.StringNull()
+		schedule.CronTimeZone = types.StringPointerValue(cronTimeZone)
+		return
+	}
+
+	cleanCronExpression, suffixTimeZone := stripCronTimeZone(*cronExpression)
+	if cronTimeZone == nil && suffixTimeZone != "" {
+		cronTimeZone = &suffixTimeZone
+	}
+
+	schedule.CronExpression = types.StringValue(cleanCronExpression)
+	schedule.CronTimeZone = types.StringPointerValue(cronTimeZone)
+}
+
+type configConnectionScheduleData struct {
+	Cron *configConnectionScheduleDataCron `json:"cron,omitempty"`
+}
+
+type configConnectionScheduleDataCron struct {
+	CronExpression string `json:"cronExpression"`
+	CronTimeZone   string `json:"cronTimeZone"`
+}
+
+type configConnectionRead struct {
+	ScheduleType string                        `json:"scheduleType"`
+	ScheduleData *configConnectionScheduleData `json:"scheduleData,omitempty"`
+}
+
+func (r *ConnectionResource) applyCronTimeZone(ctx context.Context, data *ConnectionResourceModel, connectionID string, rawResponse *http.Response) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	cronExpression, cronTimeZone, scheduleDiags := cronScheduleParts(data.Schedule)
+	diags.Append(scheduleDiags...)
+	if diags.HasError() || cronExpression == "" || cronTimeZone == "" || cronTimeZone == "UTC" {
+		return diags
+	}
+
+	authHeader := authorizationHeader(rawResponse)
+	if authHeader == "" {
+		diags.AddError("Unable to apply cron time zone", "The Airbyte API response did not include an Authorization header to reuse for the internal config API request.")
+		return diags
+	}
+
+	body := map[string]any{
+		"connectionId": connectionID,
+		"scheduleType": "cron",
+		"scheduleData": configConnectionScheduleData{
+			Cron: &configConnectionScheduleDataCron{
+				CronExpression: cronExpression,
+				CronTimeZone:   cronTimeZone,
+			},
+		},
+	}
+
+	var out configConnectionRead
+	if err := r.postConfigAPI(ctx, "/v1/connections/update", authHeader, body, &out); err != nil {
+		diags.AddError("Unable to apply cron time zone", err.Error())
+		return diags
+	}
+
+	if out.ScheduleData != nil && out.ScheduleData.Cron != nil {
+		applyCronScheduleResponse(data.Schedule, &out.ScheduleData.Cron.CronExpression, &out.ScheduleData.Cron.CronTimeZone)
+	}
+
+	return diags
+}
+
+func (r *ConnectionResource) refreshCronTimeZone(ctx context.Context, data *ConnectionResourceModel, rawResponse *http.Response) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if data == nil || data.ConnectionID.IsNull() || data.ConnectionID.IsUnknown() {
+		return diags
+	}
+
+	authHeader := authorizationHeader(rawResponse)
+	if authHeader == "" {
+		return diags
+	}
+
+	body := map[string]string{"connectionId": data.ConnectionID.ValueString()}
+
+	var out configConnectionRead
+	if err := r.postConfigAPI(ctx, "/v1/connections/get", authHeader, body, &out); err != nil {
+		return diags
+	}
+
+	if out.ScheduleType != "cron" || out.ScheduleData == nil || out.ScheduleData.Cron == nil {
+		return diags
+	}
+
+	if data.Schedule == nil {
+		data.Schedule = &tfTypes.AirbyteAPIConnectionSchedule{}
+	}
+	applyCronScheduleResponse(data.Schedule, &out.ScheduleData.Cron.CronExpression, &out.ScheduleData.Cron.CronTimeZone)
+
+	return diags
+}
+
+func authorizationHeader(response *http.Response) string {
+	if response == nil || response.Request == nil {
+		return ""
+	}
+	return response.Request.Header.Get("Authorization")
+}
+
+func (r *ConnectionResource) postConfigAPI(ctx context.Context, path string, authHeader string, body any, out any) error {
+	config := getProviderRuntimeConfig(r.client)
+	if config.ConfigAPIRoot == "" {
+		return fmt.Errorf("config_api_root is not configured")
+	}
+
+	endpoint, err := url.JoinPath(config.ConfigAPIRoot, path)
+	if err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", authHeader)
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("internal config API returned status %d: %s", response.StatusCode, string(responseBody))
+	}
+
+	if out == nil || len(responseBody) == 0 {
+		return nil
+	}
+	return json.Unmarshal(responseBody, out)
+}

--- a/internal/provider/connection_cron_timezone.go
+++ b/internal/provider/connection_cron_timezone.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	tfTypes "github.com/airbytehq/terraform-provider-airbyte/internal/provider/types"
@@ -20,19 +19,19 @@ import (
 
 type providerRuntimeConfig struct {
 	ConfigAPIRoot string
+	HTTPClient    *http.Client
 }
 
-var providerRuntimeConfigs sync.Map
-
-func storeProviderRuntimeConfig(client *sdk.SDK, config providerRuntimeConfig) {
-	providerRuntimeConfigs.Store(client, config)
+type configuredProviderData struct {
+	Client        *sdk.SDK
+	RuntimeConfig providerRuntimeConfig
 }
 
-func getProviderRuntimeConfig(client *sdk.SDK) providerRuntimeConfig {
-	if config, ok := providerRuntimeConfigs.Load(client); ok {
-		return config.(providerRuntimeConfig)
+func connectionResourceProviderData(data any) (*sdk.SDK, providerRuntimeConfig, bool) {
+	if data, ok := data.(*configuredProviderData); ok && data.Client != nil {
+		return data.Client, data.RuntimeConfig, true
 	}
-	return providerRuntimeConfig{}
+	return nil, providerRuntimeConfig{}, false
 }
 
 func deriveConfigAPIRoot(publicAPIRoot string) string {
@@ -70,7 +69,7 @@ func stringPointerValue(value string) *string {
 	return &value
 }
 
-func cronScheduleParts(schedule *tfTypes.AirbyteAPIConnectionSchedule) (string, string, diag.Diagnostics) {
+func cronScheduleParts(schedule *tfTypes.AirbyteAPIConnectionSchedule, configuredCronTimeZone string) (string, string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if schedule == nil || schedule.ScheduleType.ValueString() != "cron" {
 		return "", "", diags
@@ -83,7 +82,9 @@ func cronScheduleParts(schedule *tfTypes.AirbyteAPIConnectionSchedule) (string, 
 
 	cleanCronExpression, suffixTimeZone := stripCronTimeZone(cronExpression)
 	cronTimeZone := suffixTimeZone
-	if !schedule.CronTimeZone.IsUnknown() && !schedule.CronTimeZone.IsNull() && schedule.CronTimeZone.ValueString() != "" {
+	if configuredCronTimeZone != "" {
+		cronTimeZone = configuredCronTimeZone
+	} else if !schedule.CronTimeZone.IsUnknown() && !schedule.CronTimeZone.IsNull() && schedule.CronTimeZone.ValueString() != "" {
 		cronTimeZone = schedule.CronTimeZone.ValueString()
 	}
 	if cronTimeZone == "" {
@@ -146,6 +147,13 @@ func applyCronScheduleDataSourceResponse(schedule *tfTypes.ConnectionScheduleRes
 	schedule.CronTimeZone = types.StringPointerValue(cronTimeZone)
 }
 
+func configuredCronTimeZone(schedule *tfTypes.AirbyteAPIConnectionSchedule) string {
+	if schedule == nil || schedule.CronTimeZone.IsUnknown() || schedule.CronTimeZone.IsNull() {
+		return ""
+	}
+	return schedule.CronTimeZone.ValueString()
+}
+
 type configConnectionScheduleData struct {
 	Cron *configConnectionScheduleDataCron `json:"cron,omitempty"`
 }
@@ -160,10 +168,10 @@ type configConnectionRead struct {
 	ScheduleData *configConnectionScheduleData `json:"scheduleData,omitempty"`
 }
 
-func (r *ConnectionResource) applyCronTimeZone(ctx context.Context, data *ConnectionResourceModel, connectionID string, rawResponse *http.Response) diag.Diagnostics {
+func (r *ConnectionResource) applyCronTimeZone(ctx context.Context, data *ConnectionResourceModel, connectionID string, rawResponse *http.Response, plannedCronTimeZone string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	cronExpression, cronTimeZone, scheduleDiags := cronScheduleParts(data.Schedule)
+	cronExpression, cronTimeZone, scheduleDiags := cronScheduleParts(data.Schedule, plannedCronTimeZone)
 	diags.Append(scheduleDiags...)
 	if diags.HasError() || cronExpression == "" || cronTimeZone == "" || cronTimeZone == "UTC" {
 		return diags
@@ -199,7 +207,7 @@ func (r *ConnectionResource) applyCronTimeZone(ctx context.Context, data *Connec
 	return diags
 }
 
-func (r *ConnectionResource) refreshCronTimeZone(ctx context.Context, data *ConnectionResourceModel, rawResponse *http.Response) diag.Diagnostics {
+func (r *ConnectionResource) refreshCronTimeZone(ctx context.Context, data *ConnectionResourceModel, rawResponse *http.Response, previousCronTimeZone string) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if data == nil || data.ConnectionID.IsNull() || data.ConnectionID.IsUnknown() {
 		return diags
@@ -207,6 +215,10 @@ func (r *ConnectionResource) refreshCronTimeZone(ctx context.Context, data *Conn
 
 	authHeader := authorizationHeader(rawResponse)
 	if authHeader == "" {
+		if previousCronTimeZone != "" {
+			preserveCronTimeZone(data, previousCronTimeZone)
+			diags.AddWarning("Unable to refresh cron time zone", "The Airbyte API response did not include an Authorization header to reuse for the internal config API request.")
+		}
 		return diags
 	}
 
@@ -214,6 +226,10 @@ func (r *ConnectionResource) refreshCronTimeZone(ctx context.Context, data *Conn
 
 	var out configConnectionRead
 	if err := r.postConfigAPI(ctx, "/v1/connections/get", authHeader, body, &out); err != nil {
+		if previousCronTimeZone != "" {
+			preserveCronTimeZone(data, previousCronTimeZone)
+			diags.AddWarning("Unable to refresh cron time zone", err.Error())
+		}
 		return diags
 	}
 
@@ -229,6 +245,13 @@ func (r *ConnectionResource) refreshCronTimeZone(ctx context.Context, data *Conn
 	return diags
 }
 
+func preserveCronTimeZone(data *ConnectionResourceModel, cronTimeZone string) {
+	if data.Schedule == nil {
+		data.Schedule = &tfTypes.AirbyteAPIConnectionSchedule{}
+	}
+	data.Schedule.CronTimeZone = types.StringValue(cronTimeZone)
+}
+
 func authorizationHeader(response *http.Response) string {
 	if response == nil || response.Request == nil {
 		return ""
@@ -237,9 +260,13 @@ func authorizationHeader(response *http.Response) string {
 }
 
 func (r *ConnectionResource) postConfigAPI(ctx context.Context, path string, authHeader string, body any, out any) error {
-	config := getProviderRuntimeConfig(r.client)
+	config := r.config
 	if config.ConfigAPIRoot == "" {
 		return fmt.Errorf("config_api_root is not configured")
+	}
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
 
 	endpoint, err := url.JoinPath(config.ConfigAPIRoot, path)
@@ -260,7 +287,7 @@ func (r *ConnectionResource) postConfigAPI(ctx context.Context, path string, aut
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", authHeader)
 
-	response, err := http.DefaultClient.Do(request)
+	response, err := httpClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/connection_cron_timezone.go
+++ b/internal/provider/connection_cron_timezone.go
@@ -264,7 +264,9 @@ func (r *ConnectionResource) postConfigAPI(ctx context.Context, path string, aut
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close()
+	}()
 
 	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {

--- a/internal/provider/connection_data_source.go
+++ b/internal/provider/connection_data_source.go
@@ -263,9 +263,6 @@ func (r *ConnectionDataSource) Schema(ctx context.Context, req datasource.Schema
 					"cron_expression": schema.StringAttribute{
 						Computed: true,
 					},
-					"cron_time_zone": schema.StringAttribute{
-						Computed: true,
-					},
 					"schedule_type": schema.StringAttribute{
 						Computed: true,
 					},

--- a/internal/provider/connection_data_source.go
+++ b/internal/provider/connection_data_source.go
@@ -263,6 +263,9 @@ func (r *ConnectionDataSource) Schema(ctx context.Context, req datasource.Schema
 					"cron_expression": schema.StringAttribute{
 						Computed: true,
 					},
+					"cron_time_zone": schema.StringAttribute{
+						Computed: true,
+					},
 					"schedule_type": schema.StringAttribute{
 						Computed: true,
 					},

--- a/internal/provider/connection_data_source_sdk.go
+++ b/internal/provider/connection_data_source_sdk.go
@@ -141,7 +141,7 @@ func (r *ConnectionDataSourceModel) RefreshFromSharedConnectionResponse(ctx cont
 		r.Prefix = types.StringPointerValue(resp.Prefix)
 		r.Schedule = &tfTypes.ConnectionScheduleResponse{}
 		r.Schedule.BasicTiming = types.StringPointerValue(resp.Schedule.BasicTiming)
-		r.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)
+		applyCronScheduleDataSourceResponse(r.Schedule, resp.Schedule.CronExpression, nil)
 		r.Schedule.ScheduleType = types.StringValue(string(resp.Schedule.ScheduleType))
 		r.SourceID = types.StringValue(resp.SourceID)
 		r.Status = types.StringValue(string(resp.Status))

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -42,6 +42,7 @@ func NewConnectionResource() resource.Resource {
 type ConnectionResource struct {
 	// Provider configured SDK client.
 	client *sdk.SDK
+	config providerRuntimeConfig
 }
 
 // ConnectionResourceModel describes the resource data model.
@@ -745,18 +746,19 @@ func (r *ConnectionResource) Configure(ctx context.Context, req resource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*sdk.SDK)
+	client, config, ok := connectionResourceProviderData(req.ProviderData)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *sdk.SDK, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *configuredProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
 
 	r.client = client
+	r.config = config
 }
 
 func (r *ConnectionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -803,8 +805,9 @@ func (r *ConnectionResource) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
 		return
 	}
+	plannedCronTimeZone := configuredCronTimeZone(data.Schedule)
 	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
-	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse)...)
+	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse, plannedCronTimeZone)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -868,8 +871,9 @@ func (r *ConnectionResource) Read(ctx context.Context, req resource.ReadRequest,
 		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
 		return
 	}
+	previousCronTimeZone := configuredCronTimeZone(data.Schedule)
 	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
-	resp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse)...)
+	resp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse, previousCronTimeZone)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -919,8 +923,9 @@ func (r *ConnectionResource) Update(ctx context.Context, req resource.UpdateRequ
 		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
 		return
 	}
+	plannedCronTimeZone := configuredCronTimeZone(data.Schedule)
 	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
-	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse)...)
+	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse, plannedCronTimeZone)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -612,6 +612,14 @@ func (r *ConnectionResource) Schema(ctx context.Context, req resource.SchemaRequ
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 					},
+					"cron_time_zone": schema.StringAttribute{
+						Computed: true,
+						Optional: true,
+						PlanModifiers: []planmodifier.String{
+							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+						},
+						Description: `IANA time zone used to evaluate cron schedules, for example "America/New_York". Defaults to Airbyte's API default when omitted.`,
+					},
 					"schedule_type": schema.StringAttribute{
 						Computed: true,
 						Optional: true,
@@ -796,6 +804,7 @@ func (r *ConnectionResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -860,6 +869,7 @@ func (r *ConnectionResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+	resp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -910,6 +920,7 @@ func (r *ConnectionResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/connection_resource.go
+++ b/internal/provider/connection_resource.go
@@ -746,19 +746,18 @@ func (r *ConnectionResource) Configure(ctx context.Context, req resource.Configu
 		return
 	}
 
-	client, config, ok := connectionResourceProviderData(req.ProviderData)
+	client, ok := req.ProviderData.(*sdk.SDK)
 
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *configuredProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *sdk.SDK, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return
 	}
 
 	r.client = client
-	r.config = config
 }
 
 func (r *ConnectionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/connection_resource_sdk.go
+++ b/internal/provider/connection_resource_sdk.go
@@ -145,7 +145,7 @@ func (r *ConnectionResourceModel) RefreshFromSharedConnectionResponse(ctx contex
 			r.Schedule = &tfTypes.AirbyteAPIConnectionSchedule{}
 		}
 		r.Schedule.BasicTiming = types.StringPointerValue(resp.Schedule.BasicTiming)
-		r.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)
+		applyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)
 		r.Schedule.ScheduleType = types.StringValue(string(resp.Schedule.ScheduleType))
 		r.SourceID = types.StringValue(resp.SourceID)
 		r.Status = types.StringValue(string(resp.Status))
@@ -449,15 +449,9 @@ func (r *ConnectionResourceModel) ToSharedConnectionCreateRequest(ctx context.Co
 	var schedule *shared.AirbyteAPIConnectionSchedule
 	if r.Schedule != nil {
 		scheduleType := shared.ScheduleTypeEnum(r.Schedule.ScheduleType.ValueString())
-		cronExpression := new(string)
-		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
-			*cronExpression = r.Schedule.CronExpression.ValueString()
-		} else {
-			cronExpression = nil
-		}
 		schedule = &shared.AirbyteAPIConnectionSchedule{
 			ScheduleType:   scheduleType,
-			CronExpression: cronExpression,
+			CronExpression: cronExpressionForPublicAPI(r.Schedule),
 		}
 	}
 	dataResidency := new(string)
@@ -763,15 +757,9 @@ func (r *ConnectionResourceModel) ToSharedConnectionPatchRequest(ctx context.Con
 	var schedule *shared.AirbyteAPIConnectionSchedule
 	if r.Schedule != nil {
 		scheduleType := shared.ScheduleTypeEnum(r.Schedule.ScheduleType.ValueString())
-		cronExpression := new(string)
-		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
-			*cronExpression = r.Schedule.CronExpression.ValueString()
-		} else {
-			cronExpression = nil
-		}
 		schedule = &shared.AirbyteAPIConnectionSchedule{
 			ScheduleType:   scheduleType,
-			CronExpression: cronExpression,
+			CronExpression: cronExpressionForPublicAPI(r.Schedule),
 		}
 	}
 	dataResidency := new(string)

--- a/internal/provider/connection_resource_sdk.go
+++ b/internal/provider/connection_resource_sdk.go
@@ -449,12 +449,6 @@ func (r *ConnectionResourceModel) ToSharedConnectionCreateRequest(ctx context.Co
 	var schedule *shared.AirbyteAPIConnectionSchedule
 	if r.Schedule != nil {
 		scheduleType := shared.ScheduleTypeEnum(r.Schedule.ScheduleType.ValueString())
-		cronExpression := new(string)
-		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
-			*cronExpression = r.Schedule.CronExpression.ValueString()
-		} else {
-			cronExpression = nil
-		}
 		schedule = &shared.AirbyteAPIConnectionSchedule{
 			ScheduleType:   scheduleType,
 			CronExpression: cronExpressionForPublicAPI(r.Schedule),
@@ -763,12 +757,6 @@ func (r *ConnectionResourceModel) ToSharedConnectionPatchRequest(ctx context.Con
 	var schedule *shared.AirbyteAPIConnectionSchedule
 	if r.Schedule != nil {
 		scheduleType := shared.ScheduleTypeEnum(r.Schedule.ScheduleType.ValueString())
-		cronExpression := new(string)
-		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
-			*cronExpression = r.Schedule.CronExpression.ValueString()
-		} else {
-			cronExpression = nil
-		}
 		schedule = &shared.AirbyteAPIConnectionSchedule{
 			ScheduleType:   scheduleType,
 			CronExpression: cronExpressionForPublicAPI(r.Schedule),

--- a/internal/provider/connection_resource_sdk.go
+++ b/internal/provider/connection_resource_sdk.go
@@ -449,6 +449,12 @@ func (r *ConnectionResourceModel) ToSharedConnectionCreateRequest(ctx context.Co
 	var schedule *shared.AirbyteAPIConnectionSchedule
 	if r.Schedule != nil {
 		scheduleType := shared.ScheduleTypeEnum(r.Schedule.ScheduleType.ValueString())
+		cronExpression := new(string)
+		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
+			*cronExpression = r.Schedule.CronExpression.ValueString()
+		} else {
+			cronExpression = nil
+		}
 		schedule = &shared.AirbyteAPIConnectionSchedule{
 			ScheduleType:   scheduleType,
 			CronExpression: cronExpressionForPublicAPI(r.Schedule),
@@ -757,6 +763,12 @@ func (r *ConnectionResourceModel) ToSharedConnectionPatchRequest(ctx context.Con
 	var schedule *shared.AirbyteAPIConnectionSchedule
 	if r.Schedule != nil {
 		scheduleType := shared.ScheduleTypeEnum(r.Schedule.ScheduleType.ValueString())
+		cronExpression := new(string)
+		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
+			*cronExpression = r.Schedule.CronExpression.ValueString()
+		} else {
+			cronExpression = nil
+		}
 		schedule = &shared.AirbyteAPIConnectionSchedule{
 			ScheduleType:   scheduleType,
 			CronExpression: cronExpressionForPublicAPI(r.Schedule),

--- a/internal/provider/connections_data_source.go
+++ b/internal/provider/connections_data_source.go
@@ -262,6 +262,9 @@ func (r *ConnectionsDataSource) Schema(ctx context.Context, req datasource.Schem
 								"cron_expression": schema.StringAttribute{
 									Computed: true,
 								},
+								"cron_time_zone": schema.StringAttribute{
+									Computed: true,
+								},
 								"schedule_type": schema.StringAttribute{
 									Computed: true,
 								},

--- a/internal/provider/connections_data_source.go
+++ b/internal/provider/connections_data_source.go
@@ -262,9 +262,6 @@ func (r *ConnectionsDataSource) Schema(ctx context.Context, req datasource.Schem
 								"cron_expression": schema.StringAttribute{
 									Computed: true,
 								},
-								"cron_time_zone": schema.StringAttribute{
-									Computed: true,
-								},
 								"schedule_type": schema.StringAttribute{
 									Computed: true,
 								},

--- a/internal/provider/connections_data_source_sdk.go
+++ b/internal/provider/connections_data_source_sdk.go
@@ -146,7 +146,7 @@ func (r *ConnectionsDataSourceModel) RefreshFromSharedConnectionsResponse(ctx co
 			data.Prefix = types.StringPointerValue(dataItem.Prefix)
 			data.Schedule = &tfTypes.ConnectionScheduleResponse{}
 			data.Schedule.BasicTiming = types.StringPointerValue(dataItem.Schedule.BasicTiming)
-			data.Schedule.CronExpression = types.StringPointerValue(dataItem.Schedule.CronExpression)
+			applyCronScheduleDataSourceResponse(data.Schedule, dataItem.Schedule.CronExpression, nil)
 			data.Schedule.ScheduleType = types.StringValue(string(dataItem.Schedule.ScheduleType))
 			data.SourceID = types.StringValue(dataItem.SourceID)
 			data.Status = types.StringValue(string(dataItem.Status))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -32,13 +32,14 @@ type AirbyteProvider struct {
 
 // AirbyteProviderModel describes the provider data model.
 type AirbyteProviderModel struct {
-	BearerAuth   types.String `tfsdk:"bearer_auth"`
-	ClientID     types.String `tfsdk:"client_id"`
-	ClientSecret types.String `tfsdk:"client_secret"`
-	Password     types.String `tfsdk:"password"`
-	ServerURL    types.String `tfsdk:"server_url"`
-	TokenURL     types.String `tfsdk:"token_url"`
-	Username     types.String `tfsdk:"username"`
+	BearerAuth    types.String `tfsdk:"bearer_auth"`
+	ClientID      types.String `tfsdk:"client_id"`
+	ClientSecret  types.String `tfsdk:"client_secret"`
+	Password      types.String `tfsdk:"password"`
+	ConfigAPIRoot types.String `tfsdk:"config_api_root"`
+	ServerURL     types.String `tfsdk:"server_url"`
+	TokenURL      types.String `tfsdk:"token_url"`
+	Username      types.String `tfsdk:"username"`
 }
 
 func (p *AirbyteProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -68,6 +69,10 @@ func (p *AirbyteProvider) Schema(ctx context.Context, req provider.SchemaRequest
 				MarkdownDescription: `HTTP Basic password.`,
 				Optional:            true,
 				Sensitive:           true,
+			},
+			"config_api_root": schema.StringAttribute{
+				Description: `Internal config API root used for connection schedule features not exposed by the public API (defaults to the corresponding Airbyte config API for server_url).`,
+				Optional:    true,
 			},
 			"server_url": schema.StringAttribute{
 				Description: `Server URL (defaults to https://api.airbyte.com/v1)`,
@@ -156,6 +161,11 @@ func (p *AirbyteProvider) Configure(ctx context.Context, req provider.ConfigureR
 	}
 
 	client := sdk.New(opts...)
+	configAPIRoot := data.ConfigAPIRoot.ValueString()
+	if configAPIRoot == "" {
+		configAPIRoot = deriveConfigAPIRoot(serverUrl)
+	}
+	storeProviderRuntimeConfig(client, providerRuntimeConfig{ConfigAPIRoot: configAPIRoot})
 	resp.ActionData = client
 	resp.DataSourceData = client
 	resp.EphemeralResourceData = client

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,14 +33,14 @@ type AirbyteProvider struct {
 
 // AirbyteProviderModel describes the provider data model.
 type AirbyteProviderModel struct {
-	BearerAuth    types.String `tfsdk:"bearer_auth"`
-	ClientID      types.String `tfsdk:"client_id"`
-	ClientSecret  types.String `tfsdk:"client_secret"`
+	BearerAuth   types.String `tfsdk:"bearer_auth"`
+	ClientID     types.String `tfsdk:"client_id"`
+	ClientSecret types.String `tfsdk:"client_secret"`
 	Password      types.String `tfsdk:"password"`
 	ConfigAPIRoot types.String `tfsdk:"config_api_root"`
-	ServerURL     types.String `tfsdk:"server_url"`
-	TokenURL      types.String `tfsdk:"token_url"`
-	Username      types.String `tfsdk:"username"`
+	ServerURL    types.String `tfsdk:"server_url"`
+	TokenURL     types.String `tfsdk:"token_url"`
+	Username     types.String `tfsdk:"username"`
 }
 
 func (p *AirbyteProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -166,14 +166,14 @@ func (p *AirbyteProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if configAPIRoot == "" {
 		configAPIRoot = deriveConfigAPIRoot(serverUrl)
 	}
-	p.config = providerRuntimeConfig{
-		ConfigAPIRoot: configAPIRoot,
-		HTTPClient:    httpClient,
-	}
 	resp.ActionData = client
 	resp.DataSourceData = client
 	resp.EphemeralResourceData = client
 	resp.ListResourceData = client
+	p.config = providerRuntimeConfig{
+		ConfigAPIRoot: configAPIRoot,
+		HTTPClient:    httpClient,
+	}
 	resp.ResourceData = client
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,8 +38,8 @@ type AirbyteProviderModel struct {
 	Password      types.String `tfsdk:"password"`
 	ConfigAPIRoot types.String `tfsdk:"config_api_root"`
 	ServerURL     types.String `tfsdk:"server_url"`
-	TokenURL     types.String `tfsdk:"token_url"`
-	Username     types.String `tfsdk:"username"`
+	TokenURL      types.String `tfsdk:"token_url"`
+	Username      types.String `tfsdk:"username"`
 }
 
 func (p *AirbyteProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -165,12 +165,18 @@ func (p *AirbyteProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if configAPIRoot == "" {
 		configAPIRoot = deriveConfigAPIRoot(serverUrl)
 	}
-	storeProviderRuntimeConfig(client, providerRuntimeConfig{ConfigAPIRoot: configAPIRoot})
+	providerData := &configuredProviderData{
+		Client: client,
+		RuntimeConfig: providerRuntimeConfig{
+			ConfigAPIRoot: configAPIRoot,
+			HTTPClient:    httpClient,
+		},
+	}
 	resp.ActionData = client
 	resp.DataSourceData = client
 	resp.EphemeralResourceData = client
 	resp.ListResourceData = client
-	resp.ResourceData = client
+	resp.ResourceData = providerData
 }
 
 func (p *AirbyteProvider) Functions(_ context.Context) []func() function.Function {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,8 +38,8 @@ type AirbyteProviderModel struct {
 	Password      types.String `tfsdk:"password"`
 	ConfigAPIRoot types.String `tfsdk:"config_api_root"`
 	ServerURL     types.String `tfsdk:"server_url"`
-	TokenURL      types.String `tfsdk:"token_url"`
-	Username      types.String `tfsdk:"username"`
+	TokenURL     types.String `tfsdk:"token_url"`
+	Username     types.String `tfsdk:"username"`
 }
 
 func (p *AirbyteProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -36,7 +36,7 @@ type AirbyteProviderModel struct {
 	BearerAuth   types.String `tfsdk:"bearer_auth"`
 	ClientID     types.String `tfsdk:"client_id"`
 	ClientSecret types.String `tfsdk:"client_secret"`
-	Password      types.String `tfsdk:"password"`
+	Password     types.String `tfsdk:"password"`
 	ConfigAPIRoot types.String `tfsdk:"config_api_root"`
 	ServerURL    types.String `tfsdk:"server_url"`
 	TokenURL     types.String `tfsdk:"token_url"`
@@ -166,6 +166,10 @@ func (p *AirbyteProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if configAPIRoot == "" {
 		configAPIRoot = deriveConfigAPIRoot(serverUrl)
 	}
+	resp.ActionData = client
+	resp.DataSourceData = client
+	resp.EphemeralResourceData = client
+	resp.ListResourceData = client
 	resp.ActionData = client
 	resp.DataSourceData = client
 	resp.EphemeralResourceData = client

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -28,6 +28,7 @@ type AirbyteProvider struct {
 	// provider is built and ran locally, and "test" when running acceptance
 	// testing.
 	version string
+	config  providerRuntimeConfig
 }
 
 // AirbyteProviderModel describes the provider data model.
@@ -165,18 +166,15 @@ func (p *AirbyteProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if configAPIRoot == "" {
 		configAPIRoot = deriveConfigAPIRoot(serverUrl)
 	}
-	providerData := &configuredProviderData{
-		Client: client,
-		RuntimeConfig: providerRuntimeConfig{
-			ConfigAPIRoot: configAPIRoot,
-			HTTPClient:    httpClient,
-		},
+	p.config = providerRuntimeConfig{
+		ConfigAPIRoot: configAPIRoot,
+		HTTPClient:    httpClient,
 	}
 	resp.ActionData = client
 	resp.DataSourceData = client
 	resp.EphemeralResourceData = client
 	resp.ListResourceData = client
-	resp.ResourceData = providerData
+	resp.ResourceData = client
 }
 
 func (p *AirbyteProvider) Functions(_ context.Context) []func() function.Function {
@@ -189,7 +187,11 @@ func (p *AirbyteProvider) Actions(_ context.Context) []func() action.Action {
 
 func (p *AirbyteProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		NewConnectionResource,
+		func() resource.Resource {
+			resource := NewConnectionResource().(*ConnectionResource)
+			resource.config = p.config
+			return resource
+		},
 		NewDeclarativeSourceDefinitionResource,
 		NewDestinationResource,
 		NewDestinationDefinitionResource,

--- a/internal/provider/types/airbyte_api_connection_schedule.go
+++ b/internal/provider/types/airbyte_api_connection_schedule.go
@@ -9,5 +9,6 @@ import (
 type AirbyteAPIConnectionSchedule struct {
 	BasicTiming    types.String `tfsdk:"basic_timing"`
 	CronExpression types.String `tfsdk:"cron_expression"`
+	CronTimeZone   types.String `tfsdk:"cron_time_zone"`
 	ScheduleType   types.String `tfsdk:"schedule_type"`
 }

--- a/internal/provider/types/connection_schedule_response.go
+++ b/internal/provider/types/connection_schedule_response.go
@@ -9,5 +9,6 @@ import (
 type ConnectionScheduleResponse struct {
 	BasicTiming    types.String `tfsdk:"basic_timing"`
 	CronExpression types.String `tfsdk:"cron_expression"`
+	CronTimeZone   types.String `tfsdk:"cron_time_zone"`
 	ScheduleType   types.String `tfsdk:"schedule_type"`
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -150,9 +150,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *SDK {
 	sdk := &SDK{
-		SDKVersion: "1.3.0",
+		SDKVersion: "1.2.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.3.0 2.881.17 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.2.1 2.881.17 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -150,9 +150,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *SDK {
 	sdk := &SDK{
-		SDKVersion: "1.2.1",
+		SDKVersion: "1.3.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.2.1 2.881.17 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.3.0 2.881.17 1.0.0 github.com/airbytehq/terraform-provider-airbyte/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -23,6 +23,7 @@ python3 scripts/patch_provider_registrations.py internal/provider/provider.go
 python3 scripts/patch_config_preservation.py internal/provider
 python3 scripts/patch_workspace_notifications.py
 python3 scripts/patch_sensitive_configuration.py
+python3 scripts/patch_connection_cron_timezone.py
 go mod tidy
 """
 

--- a/scripts/patch_connection_cron_timezone.py
+++ b/scripts/patch_connection_cron_timezone.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Patch generated connection/provider files for cron time zone support.
+
+The public Connections API still accepts only `schedule.cronExpression` and
+hard-codes UTC in the server-side public API mapper. The internal config API
+supports `scheduleData.cron.cronTimeZone`, so the generated provider needs a
+small post-generation patch to:
+
+- expose `config_api_root` on the provider
+- expose `schedule.cron_time_zone` on connection resources/data sources
+- strip any legacy time zone suffix from public API cron expressions
+- call hand-written helper functions that apply/read the time zone through the
+  internal config API
+
+Usage:
+    python3 scripts/patch_connection_cron_timezone.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROVIDER_DIR = Path("internal/provider")
+TYPES_DIR = PROVIDER_DIR / "types"
+
+
+def replace_once(content: str, old: str, new: str, path: Path) -> str:
+    count = content.count(old)
+    if count != 1:
+        print(f"ERROR: Expected exactly 1 occurrence in {path}: {old!r}; found {count}", file=sys.stderr)
+        sys.exit(1)
+    return content.replace(old, new, 1)
+
+
+def insert_after_once(content: str, anchor: str, insertion: str, path: Path) -> str:
+    count = content.count(anchor)
+    if count != 1:
+        print(f"ERROR: Expected exactly 1 anchor in {path}: {anchor!r}; found {count}", file=sys.stderr)
+        sys.exit(1)
+    idx = content.find(anchor) + len(anchor)
+    return content[:idx] + insertion + content[idx:]
+
+
+def patch_file(path: Path, patcher) -> bool:
+    if not path.exists():
+        print(f"ERROR: {path} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    content = path.read_text()
+    new_content = patcher(content, path)
+    if new_content == content:
+        print(f"  Skipping {path} (already patched)")
+        return False
+
+    path.write_text(new_content)
+    print(f"  Patched {path}")
+    return True
+
+
+def patch_provider_go(content: str, path: Path) -> str:
+    if "ConfigAPIRoot types.String `tfsdk:\"config_api_root\"`" not in content:
+        content = content.replace(
+            "\tPassword     types.String `tfsdk:\"password\"`\n",
+            "\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n",
+            1,
+        )
+        content = content.replace(
+            "\tBearerAuth   types.String `tfsdk:\"bearer_auth\"`\n\tClientID     types.String `tfsdk:\"client_id\"`\n\tClientSecret types.String `tfsdk:\"client_secret\"`\n\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n\tServerURL    types.String `tfsdk:\"server_url\"`",
+            "\tBearerAuth    types.String `tfsdk:\"bearer_auth\"`\n\tClientID      types.String `tfsdk:\"client_id\"`\n\tClientSecret  types.String `tfsdk:\"client_secret\"`\n\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n\tServerURL     types.String `tfsdk:\"server_url\"`",
+            1,
+        )
+
+    if '"config_api_root": schema.StringAttribute{' not in content:
+        content = content.replace(
+            '''\t\t\t"server_url": schema.StringAttribute{
+\t\t\t\tDescription: `Server URL (defaults to https://api.airbyte.com/v1)`,
+\t\t\t\tOptional:    true,
+\t\t\t},''',
+            '''\t\t\t"config_api_root": schema.StringAttribute{
+\t\t\t\tDescription: `Internal config API root used for connection schedule features not exposed by the public API (defaults to the corresponding Airbyte config API for server_url).`,
+\t\t\t\tOptional:    true,
+\t\t\t},
+\t\t\t"server_url": schema.StringAttribute{
+\t\t\t\tDescription: `Server URL (defaults to https://api.airbyte.com/v1)`,
+\t\t\t\tOptional:    true,
+\t\t\t},''',
+            1,
+        )
+
+    if "storeProviderRuntimeConfig(client, providerRuntimeConfig{ConfigAPIRoot: configAPIRoot})" not in content:
+        content = content.replace(
+            "\tclient := sdk.New(opts...)\n",
+            "\tclient := sdk.New(opts...)\n\tconfigAPIRoot := data.ConfigAPIRoot.ValueString()\n\tif configAPIRoot == \"\" {\n\t\tconfigAPIRoot = deriveConfigAPIRoot(serverUrl)\n\t}\n\tstoreProviderRuntimeConfig(client, providerRuntimeConfig{ConfigAPIRoot: configAPIRoot})\n",
+            1,
+        )
+
+    return content
+
+
+def patch_connection_resource_go(content: str, path: Path) -> str:
+    if '"cron_time_zone": schema.StringAttribute{' not in content:
+        content = content.replace(
+            '''\t\t\t\t\t"cron_expression": schema.StringAttribute{
+\t\t\t\t\t\tComputed: true,
+\t\t\t\t\t\tOptional: true,
+\t\t\t\t\t\tPlanModifiers: []planmodifier.String{
+\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+\t\t\t\t\t\t},
+\t\t\t\t\t},''',
+            '''\t\t\t\t\t"cron_expression": schema.StringAttribute{
+\t\t\t\t\t\tComputed: true,
+\t\t\t\t\t\tOptional: true,
+\t\t\t\t\t\tPlanModifiers: []planmodifier.String{
+\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+\t\t\t\t\t\t},
+\t\t\t\t\t},
+\t\t\t\t\t"cron_time_zone": schema.StringAttribute{
+\t\t\t\t\t\tComputed: true,
+\t\t\t\t\t\tOptional: true,
+\t\t\t\t\t\tPlanModifiers: []planmodifier.String{
+\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+\t\t\t\t\t\t},
+\t\t\t\t\t\tDescription: `IANA time zone used to evaluate cron schedules, for example "America/New_York". Defaults to Airbyte's API default when omitted.`,
+\t\t\t\t\t},''',
+            1,
+        )
+
+    if "r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse)" not in content:
+        content = content.replace(
+            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+            1,
+        )
+
+    if "r.refreshCronTimeZone(ctx, data, res.RawResponse)" not in content:
+        content = content.replace(
+            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+            1,
+        )
+
+    if "r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse)" not in content:
+        content = content.replace(
+            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+            1,
+        )
+
+    return content
+
+
+def patch_connection_resource_sdk_go(content: str, path: Path) -> str:
+    content = content.replace(
+        "\tr.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)\n",
+        "\tapplyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)\n",
+    )
+    if content.count("cronExpressionForPublicAPI(r.Schedule)") == 0:
+        content = content.replace(
+            '''\t\tcronExpression := new(string)
+\t\tif !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
+\t\t\t*cronExpression = r.Schedule.CronExpression.ValueString()
+\t\t} else {
+\t\t\tcronExpression = nil
+\t\t}
+\t\tschedule = &shared.AirbyteAPIConnectionSchedule{
+\t\t\tScheduleType:   scheduleType,
+\t\t\tCronExpression: cronExpression,
+\t\t}''',
+            '''\t\tschedule = &shared.AirbyteAPIConnectionSchedule{
+\t\t\tScheduleType:   scheduleType,
+\t\t\tCronExpression: cronExpressionForPublicAPI(r.Schedule),
+\t\t}''',
+        )
+    return content
+
+
+def patch_connection_data_source_sdk_go(content: str, path: Path) -> str:
+    return content.replace(
+        "\tr.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)\n",
+        "\tapplyCronScheduleDataSourceResponse(r.Schedule, resp.Schedule.CronExpression, nil)\n",
+    )
+
+
+def patch_connections_data_source_sdk_go(content: str, path: Path) -> str:
+    return content.replace(
+        "\t\t\tdata.Schedule.CronExpression = types.StringPointerValue(dataItem.Schedule.CronExpression)\n",
+        "\t\t\tapplyCronScheduleDataSourceResponse(data.Schedule, dataItem.Schedule.CronExpression, nil)\n",
+    )
+
+
+def patch_data_source_schema(content: str, path: Path) -> str:
+    if '"cron_time_zone": schema.StringAttribute{' in content:
+        return content
+    return content.replace(
+        '''"cron_expression": schema.StringAttribute{
+Computed: true,
+},''',
+        '''"cron_expression": schema.StringAttribute{
+Computed: true,
+},
+"cron_time_zone": schema.StringAttribute{
+Computed: true,
+},''',
+        1,
+    )
+
+
+def patch_type(content: str, path: Path) -> str:
+    if "CronTimeZone" in content:
+        return content
+    return content.replace(
+        "\tCronExpression types.String `tfsdk:\"cron_expression\"`\n",
+        "\tCronExpression types.String `tfsdk:\"cron_expression\"`\n\tCronTimeZone   types.String `tfsdk:\"cron_time_zone\"`\n",
+        1,
+    )
+
+
+def main() -> None:
+    print("Patching connection cron time zone support...")
+    changed = False
+    for path, patcher in [
+        (PROVIDER_DIR / "provider.go", patch_provider_go),
+        (PROVIDER_DIR / "connection_resource.go", patch_connection_resource_go),
+        (PROVIDER_DIR / "connection_resource_sdk.go", patch_connection_resource_sdk_go),
+        (PROVIDER_DIR / "connection_data_source.go", patch_data_source_schema),
+        (PROVIDER_DIR / "connections_data_source.go", patch_data_source_schema),
+        (PROVIDER_DIR / "connection_data_source_sdk.go", patch_connection_data_source_sdk_go),
+        (PROVIDER_DIR / "connections_data_source_sdk.go", patch_connections_data_source_sdk_go),
+        (TYPES_DIR / "airbyte_api_connection_schedule.go", patch_type),
+        (TYPES_DIR / "connection_schedule_response.go", patch_type),
+    ]:
+        if patch_file(path, patcher):
+            changed = True
+
+    if changed:
+        print("Done - connection cron time zone support applied.")
+    else:
+        print("Done - all files already patched.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch_connection_cron_timezone.py
+++ b/scripts/patch_connection_cron_timezone.py
@@ -66,6 +66,24 @@ def patch_file(path: Path, patcher) -> bool:
 
 
 def patch_provider_go(content: str, path: Path) -> str:
+    content = replace_if_missing(
+        content,
+        "config  providerRuntimeConfig",
+        '''type AirbyteProvider struct {
+	// version is set to the provider version on release, "dev" when the
+	// provider is built and ran locally, and "test" when running acceptance
+	// testing.
+	version string
+}''',
+        '''type AirbyteProvider struct {
+	// version is set to the provider version on release, "dev" when the
+	// provider is built and ran locally, and "test" when running acceptance
+	// testing.
+	version string
+	config  providerRuntimeConfig
+}''',
+        path,
+    )
     content = replace_all_if_missing(
         content,
         "ConfigAPIRoot types.String `tfsdk:\"config_api_root\"`",
@@ -98,9 +116,16 @@ def patch_provider_go(content: str, path: Path) -> str:
     )
     content = replace_if_missing(
         content,
-        "providerData := &configuredProviderData{",
+        "p.config = providerRuntimeConfig{",
         "\tresp.ResourceData = client\n",
-        "\tproviderData := &configuredProviderData{\n\t\tClient: client,\n\t\tRuntimeConfig: providerRuntimeConfig{\n\t\t\tConfigAPIRoot: configAPIRoot,\n\t\t\tHTTPClient:    httpClient,\n\t\t},\n\t}\n\tresp.ResourceData = providerData\n",
+        "\tp.config = providerRuntimeConfig{\n\t\tConfigAPIRoot: configAPIRoot,\n\t\tHTTPClient:    httpClient,\n\t}\n\tresp.ResourceData = client\n",
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "resource.config = p.config",
+        "\t\tNewConnectionResource,\n",
+        "\t\tfunc() resource.Resource {\n\t\t\tresource := NewConnectionResource().(*ConnectionResource)\n\t\t\tresource.config = p.config\n\t\t\treturn resource\n\t\t},\n",
         path,
     )
 
@@ -121,24 +146,6 @@ def patch_connection_resource_go(content: str, path: Path) -> str:
         "type ConnectionResource struct {\n\t// Provider configured SDK client.\n\tclient *sdk.SDK\n}",
         "type ConnectionResource struct {\n\t// Provider configured SDK client.\n\tclient *sdk.SDK\n\tconfig providerRuntimeConfig\n}",
         path,
-    )
-    content = replace_if_missing(
-        content,
-        "connectionResourceProviderData(req.ProviderData)",
-        "client, ok := req.ProviderData.(*sdk.SDK)",
-        "client, config, ok := connectionResourceProviderData(req.ProviderData)",
-        path,
-    )
-    content = replace_if_missing(
-        content,
-        "r.config = config",
-        "\tr.client = client\n",
-        "\tr.client = client\n\tr.config = config\n",
-        path,
-    )
-    content = content.replace(
-        'fmt.Sprintf("Expected *sdk.SDK, got: %T. Please report this issue to the provider developers.", req.ProviderData)',
-        'fmt.Sprintf("Expected *configuredProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData)',
     )
     content = replace_if_missing(
         content,
@@ -260,6 +267,19 @@ def patch_connection_resource_sdk_go(content: str, path: Path) -> str:
         "applyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)",
         "\tr.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)\n",
         "\tapplyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)\n",
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "cronExpressionForPublicAPI(r.Schedule)",
+        """		cronExpression := new(string)
+		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
+			*cronExpression = r.Schedule.CronExpression.ValueString()
+		} else {
+			cronExpression = nil
+		}
+""",
+        "",
         path,
     )
     content = replace_all_if_missing(

--- a/scripts/patch_connection_cron_timezone.py
+++ b/scripts/patch_connection_cron_timezone.py
@@ -88,7 +88,7 @@ def patch_provider_go(content: str, path: Path) -> str:
         content,
         "ConfigAPIRoot types.String `tfsdk:\"config_api_root\"`",
         "\tPassword     types.String `tfsdk:\"password\"`\n",
-        "\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n",
+        "\tPassword     types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n",
     )
     content = replace_if_missing(
         content,
@@ -118,7 +118,7 @@ def patch_provider_go(content: str, path: Path) -> str:
         content,
         "p.config = providerRuntimeConfig{",
         "\tresp.ResourceData = client\n",
-        "\tp.config = providerRuntimeConfig{\n\t\tConfigAPIRoot: configAPIRoot,\n\t\tHTTPClient:    httpClient,\n\t}\n\tresp.ResourceData = client\n",
+        "\tresp.ActionData = client\n\tresp.DataSourceData = client\n\tresp.EphemeralResourceData = client\n\tresp.ListResourceData = client\n\tp.config = providerRuntimeConfig{\n\t\tConfigAPIRoot: configAPIRoot,\n\t\tHTTPClient:    httpClient,\n\t}\n\tresp.ResourceData = client\n",
         path,
     )
     content = replace_if_missing(

--- a/scripts/patch_connection_cron_timezone.py
+++ b/scripts/patch_connection_cron_timezone.py
@@ -43,6 +43,12 @@ def replace_if_missing(content: str, marker: str, old: str, new: str, path: Path
     return replace_once(content, old, new, path)
 
 
+def replace_all_if_missing(content: str, marker: str, old: str, new: str) -> str:
+    if marker in content:
+        return content
+    return content.replace(old, new)
+
+
 def patch_file(path: Path, patcher) -> bool:
     if not path.exists():
         print(f"ERROR: {path} does not exist", file=sys.stderr)
@@ -60,12 +66,11 @@ def patch_file(path: Path, patcher) -> bool:
 
 
 def patch_provider_go(content: str, path: Path) -> str:
-    content = replace_if_missing(
+    content = replace_all_if_missing(
         content,
         "ConfigAPIRoot types.String `tfsdk:\"config_api_root\"`",
         "\tPassword     types.String `tfsdk:\"password\"`\n",
         "\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n",
-        path,
     )
     content = replace_if_missing(
         content,
@@ -86,36 +91,16 @@ def patch_provider_go(content: str, path: Path) -> str:
     )
     content = replace_if_missing(
         content,
+        "configAPIRoot := data.ConfigAPIRoot.ValueString()",
+        "\tclient := sdk.New(opts...)\n",
+        "\tclient := sdk.New(opts...)\n\tconfigAPIRoot := data.ConfigAPIRoot.ValueString()\n\tif configAPIRoot == \"\" {\n\t\tconfigAPIRoot = deriveConfigAPIRoot(serverUrl)\n\t}\n",
+        path,
+    )
+    content = replace_if_missing(
+        content,
         "providerData := &configuredProviderData{",
-        """\tclient := sdk.New(opts...)
-\tconfigAPIRoot := data.ConfigAPIRoot.ValueString()
-\tif configAPIRoot == "" {
-\t\tconfigAPIRoot = deriveConfigAPIRoot(serverUrl)
-\t}
-\tresp.ActionData = client
-\tresp.DataSourceData = client
-\tresp.EphemeralResourceData = client
-\tresp.ListResourceData = client
-\tresp.ResourceData = client
-""",
-        """\tclient := sdk.New(opts...)
-\tconfigAPIRoot := data.ConfigAPIRoot.ValueString()
-\tif configAPIRoot == "" {
-\t\tconfigAPIRoot = deriveConfigAPIRoot(serverUrl)
-\t}
-\tproviderData := &configuredProviderData{
-\t\tClient: client,
-\t\tRuntimeConfig: providerRuntimeConfig{
-\t\t\tConfigAPIRoot: configAPIRoot,
-\t\t\tHTTPClient:    httpClient,
-\t\t},
-\t}
-\tresp.ActionData = client
-\tresp.DataSourceData = client
-\tresp.EphemeralResourceData = client
-\tresp.ListResourceData = client
-\tresp.ResourceData = providerData
-""",
+        "\tresp.ResourceData = client\n",
+        "\tproviderData := &configuredProviderData{\n\t\tClient: client,\n\t\tRuntimeConfig: providerRuntimeConfig{\n\t\t\tConfigAPIRoot: configAPIRoot,\n\t\t\tHTTPClient:    httpClient,\n\t\t},\n\t}\n\tresp.ResourceData = providerData\n",
         path,
     )
 
@@ -158,22 +143,112 @@ def patch_connection_resource_go(content: str, path: Path) -> str:
     content = replace_if_missing(
         content,
         "r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse, plannedCronTimeZone)",
-        "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-        "\tplannedCronTimeZone := configuredCronTimeZone(data.Schedule)\n\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse, plannedCronTimeZone)...)\n\n\tif resp.Diagnostics.HasError() {",
+        """	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ConnectionResource) Read""",
+        """	plannedCronTimeZone := configuredCronTimeZone(data.Schedule)
+	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse, plannedCronTimeZone)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ConnectionResource) Read""",
         path,
     )
     content = replace_if_missing(
         content,
         "r.refreshCronTimeZone(ctx, data, res.RawResponse, previousCronTimeZone)",
-        "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-        "\tpreviousCronTimeZone := configuredCronTimeZone(data.Schedule)\n\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse, previousCronTimeZone)...)\n\n\tif resp.Diagnostics.HasError() {",
+        """	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ConnectionResource) Update""",
+        """	previousCronTimeZone := configuredCronTimeZone(data.Schedule)
+	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+	resp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse, previousCronTimeZone)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ConnectionResource) Update""",
         path,
     )
     content = replace_if_missing(
         content,
         "r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse, plannedCronTimeZone)",
-        "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-        "\tplannedCronTimeZone := configuredCronTimeZone(data.Schedule)\n\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse, plannedCronTimeZone)...)\n\n\tif resp.Diagnostics.HasError() {",
+        """	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ConnectionResource) Delete""",
+        """	plannedCronTimeZone := configuredCronTimeZone(data.Schedule)
+	resp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)
+	resp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse, plannedCronTimeZone)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *ConnectionResource) Delete""",
         path,
     )
 
@@ -187,24 +262,11 @@ def patch_connection_resource_sdk_go(content: str, path: Path) -> str:
         "\tapplyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)\n",
         path,
     )
-    content = replace_if_missing(
+    content = replace_all_if_missing(
         content,
         "cronExpressionForPublicAPI(r.Schedule)",
-        '''\t\tcronExpression := new(string)
-\t\tif !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
-\t\t\t*cronExpression = r.Schedule.CronExpression.ValueString()
-\t\t} else {
-\t\t\tcronExpression = nil
-\t\t}
-\t\tschedule = &shared.AirbyteAPIConnectionSchedule{
-\t\t\tScheduleType:   scheduleType,
-\t\t\tCronExpression: cronExpression,
-\t\t}''',
-        '''\t\tschedule = &shared.AirbyteAPIConnectionSchedule{
-\t\t\tScheduleType:   scheduleType,
-\t\t\tCronExpression: cronExpressionForPublicAPI(r.Schedule),
-\t\t}''',
-        path,
+        "\t\t\tCronExpression: cronExpression,\n",
+        "\t\t\tCronExpression: cronExpressionForPublicAPI(r.Schedule),\n",
     )
     return content
 

--- a/scripts/patch_connection_cron_timezone.py
+++ b/scripts/patch_connection_cron_timezone.py
@@ -25,21 +25,22 @@ PROVIDER_DIR = Path("internal/provider")
 TYPES_DIR = PROVIDER_DIR / "types"
 
 
+def fail(path: Path, message: str) -> None:
+    print(f"ERROR: {path}: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
 def replace_once(content: str, old: str, new: str, path: Path) -> str:
     count = content.count(old)
     if count != 1:
-        print(f"ERROR: Expected exactly 1 occurrence in {path}: {old!r}; found {count}", file=sys.stderr)
-        sys.exit(1)
+        fail(path, f"Expected exactly 1 occurrence of {old!r}; found {count}")
     return content.replace(old, new, 1)
 
 
-def insert_after_once(content: str, anchor: str, insertion: str, path: Path) -> str:
-    count = content.count(anchor)
-    if count != 1:
-        print(f"ERROR: Expected exactly 1 anchor in {path}: {anchor!r}; found {count}", file=sys.stderr)
-        sys.exit(1)
-    idx = content.find(anchor) + len(anchor)
-    return content[:idx] + insertion + content[idx:]
+def replace_if_missing(content: str, marker: str, old: str, new: str, path: Path) -> str:
+    if marker in content:
+        return content
+    return replace_once(content, old, new, path)
 
 
 def patch_file(path: Path, patcher) -> bool:
@@ -59,25 +60,21 @@ def patch_file(path: Path, patcher) -> bool:
 
 
 def patch_provider_go(content: str, path: Path) -> str:
-    if "ConfigAPIRoot types.String `tfsdk:\"config_api_root\"`" not in content:
-        content = content.replace(
-            "\tPassword     types.String `tfsdk:\"password\"`\n",
-            "\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n",
-            1,
-        )
-        content = content.replace(
-            "\tBearerAuth   types.String `tfsdk:\"bearer_auth\"`\n\tClientID     types.String `tfsdk:\"client_id\"`\n\tClientSecret types.String `tfsdk:\"client_secret\"`\n\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n\tServerURL    types.String `tfsdk:\"server_url\"`",
-            "\tBearerAuth    types.String `tfsdk:\"bearer_auth\"`\n\tClientID      types.String `tfsdk:\"client_id\"`\n\tClientSecret  types.String `tfsdk:\"client_secret\"`\n\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n\tServerURL     types.String `tfsdk:\"server_url\"`",
-            1,
-        )
-
-    if '"config_api_root": schema.StringAttribute{' not in content:
-        content = content.replace(
-            '''\t\t\t"server_url": schema.StringAttribute{
+    content = replace_if_missing(
+        content,
+        "ConfigAPIRoot types.String `tfsdk:\"config_api_root\"`",
+        "\tPassword     types.String `tfsdk:\"password\"`\n",
+        "\tPassword      types.String `tfsdk:\"password\"`\n\tConfigAPIRoot types.String `tfsdk:\"config_api_root\"`\n",
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        '"config_api_root": schema.StringAttribute{',
+        '''\t\t\t"server_url": schema.StringAttribute{
 \t\t\t\tDescription: `Server URL (defaults to https://api.airbyte.com/v1)`,
 \t\t\t\tOptional:    true,
 \t\t\t},''',
-            '''\t\t\t"config_api_root": schema.StringAttribute{
+        '''\t\t\t"config_api_root": schema.StringAttribute{
 \t\t\t\tDescription: `Internal config API root used for connection schedule features not exposed by the public API (defaults to the corresponding Airbyte config API for server_url).`,
 \t\t\t\tOptional:    true,
 \t\t\t},
@@ -85,79 +82,115 @@ def patch_provider_go(content: str, path: Path) -> str:
 \t\t\t\tDescription: `Server URL (defaults to https://api.airbyte.com/v1)`,
 \t\t\t\tOptional:    true,
 \t\t\t},''',
-            1,
-        )
-
-    if "storeProviderRuntimeConfig(client, providerRuntimeConfig{ConfigAPIRoot: configAPIRoot})" not in content:
-        content = content.replace(
-            "\tclient := sdk.New(opts...)\n",
-            "\tclient := sdk.New(opts...)\n\tconfigAPIRoot := data.ConfigAPIRoot.ValueString()\n\tif configAPIRoot == \"\" {\n\t\tconfigAPIRoot = deriveConfigAPIRoot(serverUrl)\n\t}\n\tstoreProviderRuntimeConfig(client, providerRuntimeConfig{ConfigAPIRoot: configAPIRoot})\n",
-            1,
-        )
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "providerData := &configuredProviderData{",
+        """\tclient := sdk.New(opts...)
+\tconfigAPIRoot := data.ConfigAPIRoot.ValueString()
+\tif configAPIRoot == "" {
+\t\tconfigAPIRoot = deriveConfigAPIRoot(serverUrl)
+\t}
+\tresp.ActionData = client
+\tresp.DataSourceData = client
+\tresp.EphemeralResourceData = client
+\tresp.ListResourceData = client
+\tresp.ResourceData = client
+""",
+        """\tclient := sdk.New(opts...)
+\tconfigAPIRoot := data.ConfigAPIRoot.ValueString()
+\tif configAPIRoot == "" {
+\t\tconfigAPIRoot = deriveConfigAPIRoot(serverUrl)
+\t}
+\tproviderData := &configuredProviderData{
+\t\tClient: client,
+\t\tRuntimeConfig: providerRuntimeConfig{
+\t\t\tConfigAPIRoot: configAPIRoot,
+\t\t\tHTTPClient:    httpClient,
+\t\t},
+\t}
+\tresp.ActionData = client
+\tresp.DataSourceData = client
+\tresp.EphemeralResourceData = client
+\tresp.ListResourceData = client
+\tresp.ResourceData = providerData
+""",
+        path,
+    )
 
     return content
 
 
 def patch_connection_resource_go(content: str, path: Path) -> str:
-    if '"cron_time_zone": schema.StringAttribute{' not in content:
-        content = content.replace(
-            '''\t\t\t\t\t"cron_expression": schema.StringAttribute{
-\t\t\t\t\t\tComputed: true,
-\t\t\t\t\t\tOptional: true,
-\t\t\t\t\t\tPlanModifiers: []planmodifier.String{
-\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-\t\t\t\t\t\t},
-\t\t\t\t\t},''',
-            '''\t\t\t\t\t"cron_expression": schema.StringAttribute{
-\t\t\t\t\t\tComputed: true,
-\t\t\t\t\t\tOptional: true,
-\t\t\t\t\t\tPlanModifiers: []planmodifier.String{
-\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-\t\t\t\t\t\t},
-\t\t\t\t\t},
-\t\t\t\t\t"cron_time_zone": schema.StringAttribute{
-\t\t\t\t\t\tComputed: true,
-\t\t\t\t\t\tOptional: true,
-\t\t\t\t\t\tPlanModifiers: []planmodifier.String{
-\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-\t\t\t\t\t\t},
-\t\t\t\t\t\tDescription: `IANA time zone used to evaluate cron schedules, for example "America/New_York". Defaults to Airbyte's API default when omitted.`,
-\t\t\t\t\t},''',
-            1,
-        )
-
-    if "r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse)" not in content:
-        content = content.replace(
-            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-            1,
-        )
-
-    if "r.refreshCronTimeZone(ctx, data, res.RawResponse)" not in content:
-        content = content.replace(
-            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-            1,
-        )
-
-    if "r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse)" not in content:
-        content = content.replace(
-            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-            "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
-            1,
-        )
+    content = replace_if_missing(
+        content,
+        '"cron_time_zone": schema.StringAttribute{',
+        '\t\t\t\t\t"cron_expression": schema.StringAttribute{\n\t\t\t\t\t\tComputed: true,\n\t\t\t\t\t\tOptional: true,\n\t\t\t\t\t\tPlanModifiers: []planmodifier.String{\n\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),\n\t\t\t\t\t\t},\n\t\t\t\t\t},',
+        '\t\t\t\t\t"cron_expression": schema.StringAttribute{\n\t\t\t\t\t\tComputed: true,\n\t\t\t\t\t\tOptional: true,\n\t\t\t\t\t\tPlanModifiers: []planmodifier.String{\n\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),\n\t\t\t\t\t\t},\n\t\t\t\t\t},\n\t\t\t\t\t"cron_time_zone": schema.StringAttribute{\n\t\t\t\t\t\tComputed: true,\n\t\t\t\t\t\tOptional: true,\n\t\t\t\t\t\tPlanModifiers: []planmodifier.String{\n\t\t\t\t\t\t\tspeakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),\n\t\t\t\t\t\t},\n\t\t\t\t\t\tDescription: `IANA time zone used to evaluate cron schedules, for example "America/New_York". Defaults to Airbyte\'s API default when omitted.`,\n\t\t\t\t\t},',
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "config providerRuntimeConfig",
+        "type ConnectionResource struct {\n\t// Provider configured SDK client.\n\tclient *sdk.SDK\n}",
+        "type ConnectionResource struct {\n\t// Provider configured SDK client.\n\tclient *sdk.SDK\n\tconfig providerRuntimeConfig\n}",
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "connectionResourceProviderData(req.ProviderData)",
+        "client, ok := req.ProviderData.(*sdk.SDK)",
+        "client, config, ok := connectionResourceProviderData(req.ProviderData)",
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "r.config = config",
+        "\tr.client = client\n",
+        "\tr.client = client\n\tr.config = config\n",
+        path,
+    )
+    content = content.replace(
+        'fmt.Sprintf("Expected *sdk.SDK, got: %T. Please report this issue to the provider developers.", req.ProviderData)',
+        'fmt.Sprintf("Expected *configuredProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData)',
+    )
+    content = replace_if_missing(
+        content,
+        "r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse, plannedCronTimeZone)",
+        "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+        "\tplannedCronTimeZone := configuredCronTimeZone(data.Schedule)\n\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, res.ConnectionResponse.ConnectionID, res.RawResponse, plannedCronTimeZone)...)\n\n\tif resp.Diagnostics.HasError() {",
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "r.refreshCronTimeZone(ctx, data, res.RawResponse, previousCronTimeZone)",
+        "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+        "\tpreviousCronTimeZone := configuredCronTimeZone(data.Schedule)\n\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.refreshCronTimeZone(ctx, data, res.RawResponse, previousCronTimeZone)...)\n\n\tif resp.Diagnostics.HasError() {",
+        path,
+    )
+    content = replace_if_missing(
+        content,
+        "r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse, plannedCronTimeZone)",
+        "\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\n\tif resp.Diagnostics.HasError() {",
+        "\tplannedCronTimeZone := configuredCronTimeZone(data.Schedule)\n\tresp.Diagnostics.Append(data.RefreshFromSharedConnectionResponse(ctx, res.ConnectionResponse)...)\n\tresp.Diagnostics.Append(r.applyCronTimeZone(ctx, data, request.ConnectionID, res.RawResponse, plannedCronTimeZone)...)\n\n\tif resp.Diagnostics.HasError() {",
+        path,
+    )
 
     return content
 
-
 def patch_connection_resource_sdk_go(content: str, path: Path) -> str:
-    content = content.replace(
+    content = replace_if_missing(
+        content,
+        "applyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)",
         "\tr.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)\n",
         "\tapplyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)\n",
+        path,
     )
-    if content.count("cronExpressionForPublicAPI(r.Schedule)") == 0:
-        content = content.replace(
-            '''\t\tcronExpression := new(string)
+    content = replace_if_missing(
+        content,
+        "cronExpressionForPublicAPI(r.Schedule)",
+        '''\t\tcronExpression := new(string)
 \t\tif !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
 \t\t\t*cronExpression = r.Schedule.CronExpression.ValueString()
 \t\t} else {
@@ -167,52 +200,73 @@ def patch_connection_resource_sdk_go(content: str, path: Path) -> str:
 \t\t\tScheduleType:   scheduleType,
 \t\t\tCronExpression: cronExpression,
 \t\t}''',
-            '''\t\tschedule = &shared.AirbyteAPIConnectionSchedule{
+        '''\t\tschedule = &shared.AirbyteAPIConnectionSchedule{
 \t\t\tScheduleType:   scheduleType,
 \t\t\tCronExpression: cronExpressionForPublicAPI(r.Schedule),
 \t\t}''',
-        )
+        path,
+    )
     return content
 
 
 def patch_connection_data_source_sdk_go(content: str, path: Path) -> str:
-    return content.replace(
+    return replace_if_missing(
+        content,
+        "applyCronScheduleDataSourceResponse(r.Schedule, resp.Schedule.CronExpression, nil)",
         "\tr.Schedule.CronExpression = types.StringPointerValue(resp.Schedule.CronExpression)\n",
         "\tapplyCronScheduleDataSourceResponse(r.Schedule, resp.Schedule.CronExpression, nil)\n",
+        path,
     )
 
 
 def patch_connections_data_source_sdk_go(content: str, path: Path) -> str:
-    return content.replace(
+    return replace_if_missing(
+        content,
+        "applyCronScheduleDataSourceResponse(data.Schedule, dataItem.Schedule.CronExpression, nil)",
         "\t\t\tdata.Schedule.CronExpression = types.StringPointerValue(dataItem.Schedule.CronExpression)\n",
         "\t\t\tapplyCronScheduleDataSourceResponse(data.Schedule, dataItem.Schedule.CronExpression, nil)\n",
+        path,
     )
+
+
+def add_cron_time_zone_schema(content: str, path: Path) -> str:
+    if '"cron_time_zone": schema.StringAttribute{' in content:
+        return content
+
+    lines = content.splitlines(keepends=True)
+    matches = [index for index, line in enumerate(lines) if '"cron_expression": schema.StringAttribute{' in line]
+    if len(matches) != 1:
+        fail(path, f"Expected exactly 1 cron_expression schema attribute; found {len(matches)}")
+
+    start = matches[0]
+    end = None
+    for index in range(start + 1, len(lines)):
+        if lines[index].strip() == "},":
+            end = index
+            break
+    if end is None:
+        fail(path, "Could not find end of cron_expression schema attribute")
+
+    indent = lines[start].split('"cron_expression"')[0]
+    insertion = [
+        f'{indent}"cron_time_zone": schema.StringAttribute{{\n',
+        f"{indent}\tComputed: true,\n",
+        f"{indent}}},\n",
+    ]
+    return "".join(lines[: end + 1] + insertion + lines[end + 1 :])
 
 
 def patch_data_source_schema(content: str, path: Path) -> str:
-    if '"cron_time_zone": schema.StringAttribute{' in content:
-        return content
-    return content.replace(
-        '''"cron_expression": schema.StringAttribute{
-Computed: true,
-},''',
-        '''"cron_expression": schema.StringAttribute{
-Computed: true,
-},
-"cron_time_zone": schema.StringAttribute{
-Computed: true,
-},''',
-        1,
-    )
+    return add_cron_time_zone_schema(content, path)
 
 
 def patch_type(content: str, path: Path) -> str:
-    if "CronTimeZone" in content:
-        return content
-    return content.replace(
+    return replace_if_missing(
+        content,
+        "CronTimeZone",
         "\tCronExpression types.String `tfsdk:\"cron_expression\"`\n",
         "\tCronExpression types.String `tfsdk:\"cron_expression\"`\n\tCronTimeZone   types.String `tfsdk:\"cron_time_zone\"`\n",
-        1,
+        path,
     )
 
 

--- a/scripts/patch_connection_cron_timezone.py
+++ b/scripts/patch_connection_cron_timezone.py
@@ -269,25 +269,21 @@ def patch_connection_resource_sdk_go(content: str, path: Path) -> str:
         "\tapplyCronScheduleResponse(r.Schedule, resp.Schedule.CronExpression, nil)\n",
         path,
     )
-    content = replace_if_missing(
-        content,
-        "cronExpressionForPublicAPI(r.Schedule)",
-        """		cronExpression := new(string)
-		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
-			*cronExpression = r.Schedule.CronExpression.ValueString()
-		} else {
-			cronExpression = nil
-		}
-""",
-        "",
-        path,
-    )
     content = replace_all_if_missing(
         content,
         "cronExpressionForPublicAPI(r.Schedule)",
         "\t\t\tCronExpression: cronExpression,\n",
         "\t\t\tCronExpression: cronExpressionForPublicAPI(r.Schedule),\n",
     )
+    if "cronExpressionForPublicAPI(r.Schedule)" in content:
+        old_block = """		cronExpression := new(string)
+		if !r.Schedule.CronExpression.IsUnknown() && !r.Schedule.CronExpression.IsNull() {
+			*cronExpression = r.Schedule.CronExpression.ValueString()
+		} else {
+			cronExpression = nil
+		}
+"""
+        content = content.replace(old_block, "")
     return content
 
 


### PR DESCRIPTION
## Summary
Adds draft support for real IANA cron time zones on `airbyte_connection` by using Airbyte's internal/config API for the schedule timezone field that the public Connections API does not expose.

Key findings:
- The public API schedule schema only exposes `scheduleType` and `cronExpression`; public create/update mappers do not expose a timezone field.
- The internal config API already exposes `scheduleData.cron.cronTimeZone`, and Airbyte workers evaluate schedules using that IANA timezone.
- The provider can keep the generated public API CRUD flow, then apply/read the timezone through `/api/v1/connections/update` and `/api/v1/connections/get`.

Changes in this PR:
- Adds provider-level `config_api_root`, defaulting from `server_url`.
- Adds `schedule.cron_time_zone` for connection resources and connection data-source schedule shapes.
- Keeps public API requests timezone-free by stripping legacy timezone suffixes from `cron_expression`.
- Applies connection resource time zones through provider-scoped runtime config while keeping generated resource `ProviderData` compatible with `*sdk.SDK`.
- Reuses the configured provider HTTP client for internal/config API calls.
- Preserves the prior state value and surfaces warnings when the config API cannot refresh an already-configured timezone.
- Adds a post-generation patch script so the generated provider changes are reproducible, with stricter anchor validation.
- Aligns generated docs/code artifacts with CI generation output.

## Review & Testing Checklist for Human
- [ ] Confirm the internal config API is acceptable for Terraform provider runtime use in Airbyte Cloud and OSS/Enterprise deployments.
- [ ] Run a sandbox apply with `schedule = { schedule_type = "cron", cron_expression = "0 0 12 * * ?", cron_time_zone = "America/New_York" }` and verify the Airbyte connection stores `scheduleData.cron.cronTimeZone = "America/New_York"`.
- [ ] Validate auth behavior for `config_api_root` in Cloud, especially whether a public API bearer token can call `https://cloud.airbyte.com/api/v1/connections/update`.
- [ ] Verify connection data sources can read scheduled connections after the new `cron_time_zone` schema attribute is present.

### Notes
Local verification performed:
- `python3 scripts/patch_connection_cron_timezone.py`
- `uvx --from=poethepoet poe post-generate`
- downloaded CI `generated_provider_code` artifact from run `26424475179` and matched `internal/provider` + `internal/sdk` with `diff -rq`
- `go build ./...`
- `go test ./...`
- `poe -C /home/ubuntu/repos/terraform-provider-airbyte docs-generate`

Earlier CI verification passed all PR checks before the review-fix commits, including build, docs drift, generated-code zero-diff, E2E smoke test, and Terraform acceptance matrix. Latest CI is pending after the zero-diff alignment fix.

This is intentionally a draft because the implementation depends on whether calling internal/config APIs from the provider is product/API-supported.

Requested by: @aaronsteers

Link to Devin session: https://app.devin.ai/sessions/76466ef911ea4604b7be6d5a055e5f7c