### PR TITLE
ci: add pre-release workflow for testing provider builds

### DIFF
--- a/.github/pr-welcome-message.md
+++ b/.github/pr-welcome-message.md
@@ -13,6 +13,13 @@ Your contribution is appreciated. Here are some helpful tips and resources.
 - `/tf-examples project=pre-1.0 action=apply` - Apply terraform changes to the pre-1.0 example project
 - `/tf-examples project=pre-1.0 action=destroy` - Destroy terraform resources in the pre-1.0 example project
 
+### Pre-Release Commands
+
+- `/pre-release version=v1.3.0-rc.1` - Build and publish a pre-release from this PR's branch
+- `/pre-release version=v1.3.0-rc.1 ref=some-branch` - Build a pre-release from a specific branch
+
+Pre-releases are published to the Terraform Registry but are **not** the default version. See [CONTRIBUTING.md — Pre-Release Process](CONTRIBUTING.md#pre-release-process) for details.
+
 </details>
 
 <details>

--- a/.github/pr-welcome-message.md
+++ b/.github/pr-welcome-message.md
@@ -16,7 +16,6 @@ Your contribution is appreciated. Here are some helpful tips and resources.
 ### Pre-Release Commands
 
 - `/pre-release version=v1.3.0-rc.1` - Build and publish a pre-release from this PR's branch
-- `/pre-release version=v1.3.0-rc.1 ref=some-branch` - Build a pre-release from a specific branch
 
 Pre-releases are published to the Terraform Registry but are **not** the default version. See [CONTRIBUTING.md — Pre-Release Process](CONTRIBUTING.md#pre-release-process) for details.
 

--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -21,13 +21,14 @@
 #     command on a PR, this defaults to the PR's head branch.
 #
 # How it works:
-#   1. Validates that `version` contains a pre-release suffix (safety check).
+#   1. Validates that `version` is valid semver with a pre-release suffix (safety check).
 #   2. Checks out the specified ref.
-#   3. Creates and pushes a git tag for the pre-release version.
-#   4. Runs GoReleaser with .goreleaser.prerelease.yml, which publishes a
+#   3. Fails if the version has already been published (existing release or tag).
+#   4. Creates and pushes a git tag for the pre-release version.
+#   5. Runs GoReleaser with .goreleaser.prerelease.yml, which publishes a
 #      non-draft, prerelease GitHub Release with GPG-signed cross-platform
 #      binaries and the terraform-registry-manifest.json.
-#   5. The Terraform Registry picks up the prerelease automatically.
+#   6. The Terraform Registry picks up the prerelease automatically.
 #
 # This workflow does NOT conflict with the Release Drafter workflow:
 #   - Release Drafter → draft releases for stable versions
@@ -129,10 +130,12 @@ jobs:
             exit 1
           fi
 
-          # Ensure version contains a pre-release suffix (hyphen after the semver core)
-          # Matches: v1.2.3-rc.1, v1.2.3-beta.1, v1.2.3-alpha.1, etc.
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
-            echo "::error::Version must contain a pre-release suffix (e.g. -rc.1, -beta.1). Got: $VERSION"
+          # Strict semver validation (no leading zeros, valid pre-release identifiers)
+          # Per semver.org: MAJOR.MINOR.PATCH-PRERELEASE where each numeric part has no leading zeros,
+          # and pre-release is dot-separated alphanumeric identifiers (numeric ones must not have leading zeros).
+          SEMVER_RE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(([0-9A-Za-z-]+\.)*[0-9A-Za-z-]+)$'
+          if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
+            echo "::error::Invalid semver or missing pre-release suffix. Expected format: vMAJOR.MINOR.PATCH-PRERELEASE (e.g. v1.3.0-rc.1). Got: $VERSION"
             echo "::error::This workflow is for pre-releases only. Use the Release Drafter for stable releases."
             exit 1
           fi
@@ -158,17 +161,29 @@ jobs:
           gpg_private_key: ${{ secrets.TERRAFORM_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.TERRAFORM_GPG_PASSPHRASE }}
 
-      # ── Tag the commit ──────────────────────────────────────────────
-      - name: Create and push tag
+      # ── Check if version is already published ─────────────────────
+      - name: Check for existing release or tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ inputs.version }}"
 
-          # Fail early if the tag already exists on the remote
+          # Fail if a GitHub Release already exists for this version
+          if gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::Release $VERSION already exists. Use a different version or delete the existing release first."
+            exit 1
+          fi
+
+          # Fail if the tag already exists on the remote (even without a release)
           if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
             echo "::error::Tag $VERSION already exists on the remote. Use a different version."
             exit 1
           fi
 
+      # ── Tag the commit ──────────────────────────────────────────────
+      - name: Create and push tag
+        run: |
+          VERSION="${{ inputs.version }}"
           git tag -a "$VERSION" -m "Pre-release $VERSION"
           git push origin "$VERSION"
 

--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -4,15 +4,21 @@
 # Pre-releases are visible on the Terraform Registry but are NOT the default
 # version, so existing users are unaffected.
 #
-# Usage (from the Actions tab → "Pre-Release" → "Run workflow"):
+# Triggers:
+# - Manual workflow_dispatch: From the Actions tab
+# - Slash command: `/pre-release version=v1.3.0-rc.1` on a PR comment
+#   (optionally: `/pre-release version=v1.3.0-rc.1 ref=my-branch`)
 #
-#   version:  The pre-release version tag (REQUIRED).
-#             Must contain a pre-release suffix: -rc.N, -beta.N, -alpha.N, etc.
-#             Examples: v1.3.0-rc.1, v1.3.0-beta.1, v2.0.0-alpha.3
+# Inputs:
 #
-#   ref:      The branch, tag, or commit SHA to build from (default: main).
-#             Use a feature branch name to test unreleased code, or a PR
-#             merge-commit SHA for validating community contributions.
+#   version (REQUIRED): The pre-release version tag.
+#     Must contain a pre-release suffix: -rc.N, -beta.N, -alpha.N, etc.
+#     Examples: v1.3.0-rc.1, v1.3.0-beta.1, v2.0.0-alpha.3
+#
+#   ref (optional, default: main): The branch, tag, or commit SHA to build from.
+#     Use a feature branch name to test unreleased code, or a PR merge-commit
+#     SHA for validating community contributions. When triggered via slash
+#     command on a PR, this defaults to the PR's head branch.
 #
 # How it works:
 #   1. Validates that `version` contains a pre-release suffix (safety check).
@@ -54,6 +60,18 @@ on:
         required: false
         default: 'main'
         type: string
+      pr:
+        description: 'PR number (for slash command triggers)'
+        required: false
+        type: string
+      comment-id:
+        description: 'Comment ID (for slash command triggers)'
+        required: false
+        type: string
+
+concurrency:
+  group: pre-release-${{ inputs.version }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -63,8 +81,43 @@ jobs:
     name: Build & Publish Pre-Release
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest-16core
     steps:
+      # ── Slash command: post starting comment ────────────────────────
+      - name: Authenticate as GitHub App
+        if: ${{ inputs.pr != '' }}
+        uses: actions/create-github-app-token@v3
+        id: get-app-token
+        with:
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Post starting comment
+        if: ${{ inputs.pr != '' }}
+        id: start-comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          issue-number: ${{ inputs.pr }}
+          comment-id: ${{ inputs.comment-id || '' }}
+          body: |
+            > **Pre-Release Job Info**
+            >
+            > Building pre-release `${{ inputs.version }}` from ref `${{ inputs.ref || 'PR head branch' }}`.
+
+            > Job started... [Check job output.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      # ── Resolve ref from PR if not explicitly provided ──────────────
+      - name: Resolve PR head branch
+        if: ${{ inputs.pr != '' && inputs.ref == 'main' }}
+        id: resolve-ref
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          PR_HEAD=$(gh pr view "${{ inputs.pr }}" --repo "${{ github.repository }}" --json headRefName -q '.headRefName')
+          echo "ref=$PR_HEAD" >> "$GITHUB_OUTPUT"
+
       # ── Validate version input ──────────────────────────────────────
       - name: Validate pre-release version
         run: |
@@ -89,7 +142,7 @@ jobs:
       # ── Checkout ────────────────────────────────────────────────────
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ steps.resolve-ref.outputs.ref || inputs.ref }}
           fetch-depth: 0
 
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
@@ -109,7 +162,14 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ inputs.version }}"
-          git tag "$VERSION"
+
+          # Fail early if the tag already exists on the remote
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
+            echo "::error::Tag $VERSION already exists on the remote. Use a different version."
+            exit 1
+          fi
+
+          git tag -a "$VERSION" -m "Pre-release $VERSION"
           git push origin "$VERSION"
 
       # ── Build and publish with GoReleaser ───────────────────────────
@@ -123,3 +183,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GORELEASER_CURRENT_TAG: ${{ inputs.version }}
+
+      # ── Slash command: post result comment ──────────────────────────
+      - name: Post success comment
+        if: ${{ always() && inputs.pr != '' }}
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ steps.get-app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > **Pre-Release Result:** ${{ job.status == 'success' && '✅ Published' || '❌ Failed' }}
+            >
+            > Version: `${{ inputs.version }}`
+            > Ref: `${{ steps.resolve-ref.outputs.ref || inputs.ref }}`
+            > [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            ${{ job.status == 'success' && format('> [View release]({0}/{1}/releases/tag/{2})', github.server_url, github.repository, inputs.version) || '' }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,125 @@
+# Pre-Release Workflow
+#
+# Builds and publishes a pre-release version of the Terraform provider.
+# Pre-releases are visible on the Terraform Registry but are NOT the default
+# version, so existing users are unaffected.
+#
+# Usage (from the Actions tab → "Pre-Release" → "Run workflow"):
+#
+#   version:  The pre-release version tag (REQUIRED).
+#             Must contain a pre-release suffix: -rc.N, -beta.N, -alpha.N, etc.
+#             Examples: v1.3.0-rc.1, v1.3.0-beta.1, v2.0.0-alpha.3
+#
+#   ref:      The branch, tag, or commit SHA to build from (default: main).
+#             Use a feature branch name to test unreleased code, or a PR
+#             merge-commit SHA for validating community contributions.
+#
+# How it works:
+#   1. Validates that `version` contains a pre-release suffix (safety check).
+#   2. Checks out the specified ref.
+#   3. Creates and pushes a git tag for the pre-release version.
+#   4. Runs GoReleaser with .goreleaser.prerelease.yml, which publishes a
+#      non-draft, prerelease GitHub Release with GPG-signed cross-platform
+#      binaries and the terraform-registry-manifest.json.
+#   5. The Terraform Registry picks up the prerelease automatically.
+#
+# This workflow does NOT conflict with the Release Drafter workflow:
+#   - Release Drafter → draft releases for stable versions
+#   - This workflow   → non-draft pre-releases for testing
+#
+# To install a pre-release in Terraform:
+#
+#   terraform {
+#     required_providers {
+#       airbyte = {
+#         source  = "airbytehq/airbyte"
+#         version = "1.3.0-rc.1"  # note: no 'v' prefix in Terraform
+#       }
+#     }
+#   }
+
+name: Pre-Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Pre-release version tag (e.g. v1.3.0-rc.1, v1.3.0-beta.1).
+          MUST contain a pre-release suffix.
+        required: true
+        type: string
+      ref:
+        description: 'Branch, tag, or commit SHA to build from'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  pre_release:
+    name: Build & Publish Pre-Release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest-16core
+    steps:
+      # ── Validate version input ──────────────────────────────────────
+      - name: Validate pre-release version
+        run: |
+          VERSION="${{ inputs.version }}"
+
+          # Ensure version starts with 'v'
+          if [[ ! "$VERSION" =~ ^v ]]; then
+            echo "::error::Version must start with 'v' (e.g. v1.3.0-rc.1). Got: $VERSION"
+            exit 1
+          fi
+
+          # Ensure version contains a pre-release suffix (hyphen after the semver core)
+          # Matches: v1.2.3-rc.1, v1.2.3-beta.1, v1.2.3-alpha.1, etc.
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            echo "::error::Version must contain a pre-release suffix (e.g. -rc.1, -beta.1). Got: $VERSION"
+            echo "::error::This workflow is for pre-releases only. Use the Release Drafter for stable releases."
+            exit 1
+          fi
+
+          echo "Pre-release version validated: $VERSION"
+
+      # ── Checkout ────────────────────────────────────────────────────
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # ── GPG signing (same setup as release-drafter.yml) ─────────────
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.TERRAFORM_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.TERRAFORM_GPG_PASSPHRASE }}
+
+      # ── Tag the commit ──────────────────────────────────────────────
+      - name: Create and push tag
+        run: |
+          VERSION="${{ inputs.version }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      # ── Build and publish with GoReleaser ───────────────────────────
+      # Uses .goreleaser.prerelease.yml which sets draft=false, prerelease=true.
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        with:
+          args: release --clean --config .goreleaser.prerelease.yml
+          version: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.version }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -35,6 +35,7 @@ jobs:
           commands: |
             tf-examples
             generate
+            pre-release
           static-args: |
             pr=${{ github.event.issue.number }}
             comment-id=${{ github.event.comment.id }}

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -1,0 +1,71 @@
+# GoReleaser configuration for pre-releases.
+#
+# This is a variant of .goreleaser.yml used by the pre-release workflow.
+# Differences from the production config:
+#   - release.draft = false   (immediately visible, not a draft)
+#   - release.prerelease = true (Terraform Registry won't make it the default)
+#   - release.use_existing_draft removed (creates a new release)
+#   - changelog.disable removed (includes auto-generated changelog)
+#
+# Do NOT use this config for stable releases — use .goreleaser.yml via the
+# Release Drafter workflow instead.
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  draft: false
+  prerelease: true
+  replace_existing_artifacts: true
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,10 +208,8 @@ uvx --from=poethepoet poe <task-name>
 |------|---------|
 | `scripts/generate_terraform_spec.py` | Generates the Terraform-specific OpenAPI spec from upstream sources |
 | `overlays/terraform_speakeasy.yaml` | Speakeasy overlay for Terraform-specific customizations |
-| `.github/workflows/release-drafter.yml` | Creates draft releases with pre-built assets |
-| `.github/workflows/pre-release-command.yml` | Builds and publishes pre-release versions for testing |
-| `.goreleaser.prerelease.yml` | GoReleaser config for non-draft pre-releases |
-| `.github/workflows/generate-command.yml` | Triggers provider regeneration via Speakeasy |
+| `.github/workflows/*` | CI/CD workflows (release, pre-release, generation, testing) |
+| `.goreleaser*.yml` | GoReleaser configs (stable and pre-release) |
 
 ### End-to-End Testing with CI Artifacts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,10 +99,7 @@ Pre-releases let you publish a provider version for testing without making it th
    ```
    /pre-release version=v1.3.0-rc.1
    ```
-   This builds from the PR's head branch. You can override the ref:
-   ```
-   /pre-release version=v1.3.0-rc.1 ref=some-branch
-   ```
+   This builds from the PR's head branch.
 
 2. **Manual workflow dispatch** (from the [Actions tab](https://github.com/airbytehq/terraform-provider-airbyte/actions/workflows/pre-release-command.yml)):
    - **version** (required): e.g. `v1.3.0-rc.1`, `v1.3.0-beta.1`. Must be valid semver with a pre-release suffix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,42 @@ Releases use a draft-based workflow:
 
 **Important**: Do not check "Set as a pre-release" unless you want to delay Terraform Registry sync.
 
+### Pre-Release Process
+
+Pre-releases let you publish a provider version for testing without making it the default on the Terraform Registry. Use this to validate community contributions or new features before a stable release.
+
+**Two ways to trigger a pre-release:**
+
+1. **Slash command on a PR** (recommended for PR-based work):
+   ```
+   /pre-release version=v1.3.0-rc.1
+   ```
+   This builds from the PR's head branch. You can override the ref:
+   ```
+   /pre-release version=v1.3.0-rc.1 ref=some-branch
+   ```
+
+2. **Manual workflow dispatch** (from the [Actions tab](https://github.com/airbytehq/terraform-provider-airbyte/actions/workflows/pre-release-command.yml)):
+   - **version** (required): e.g. `v1.3.0-rc.1`, `v1.3.0-beta.1`. Must be valid semver with a pre-release suffix.
+   - **ref** (optional, default: `main`): branch, tag, or commit SHA to build from.
+
+**Safety checks** — the workflow will fail if:
+- The version is not valid semver or is missing a pre-release suffix (e.g. `v1.3.0` is rejected)
+- A GitHub Release or git tag already exists for the version
+
+**Using a pre-release in Terraform:**
+
+```hcl
+terraform {
+  required_providers {
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "1.3.0-rc.1"  # no 'v' prefix in Terraform
+    }
+  }
+}
+```
+
 ### Maintenance Branches and Backporting
 
 Following the [HashiCorp convention](https://github.com/terraform-providers/terraform-provider-aws/pull/14177) used by Terraform providers such as `terraform-provider-aws`, this project uses `release/` branches for maintaining older major or minor versions:
@@ -176,6 +212,8 @@ uvx --from=poethepoet poe <task-name>
 | `scripts/generate_terraform_spec.py` | Generates the Terraform-specific OpenAPI spec from upstream sources |
 | `overlays/terraform_speakeasy.yaml` | Speakeasy overlay for Terraform-specific customizations |
 | `.github/workflows/release-drafter.yml` | Creates draft releases with pre-built assets |
+| `.github/workflows/pre-release-command.yml` | Builds and publishes pre-release versions for testing |
+| `.goreleaser.prerelease.yml` | GoReleaser config for non-draft pre-releases |
 | `.github/workflows/generate-command.yml` | Triggers provider regeneration via Speakeasy |
 
 ### End-to-End Testing with CI Artifacts


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch`-triggered pre-release workflow so we can safely test provider builds (e.g. PR #222's Google IAP auth) before publishing them as the latest stable version. Requested by @aaronsteers.

**Files changed (no existing release files modified):**

- **`.github/workflows/pre-release-command.yml`** — The workflow. Inputs:
  - `version` (required): e.g. `v1.3.0-rc.1`. Validated against strict semver (no leading zeros, valid pre-release identifiers); rejects stable versions like `v1.3.0`.
  - `ref` (optional, default `main`): branch/commit to build from. Auto-resolves PR head branch when triggered via slash command.
  
  Steps: validate semver → checkout ref → fail if release or tag already exists → import GPG key → create annotated tag + push → GoReleaser with `--config .goreleaser.prerelease.yml`.

  Slash command: `/pre-release version=v1.3.0-rc.1` on any PR comment (builds from PR head branch). Posts start/result comments.

- **`.goreleaser.prerelease.yml`** — Same build/sign/checksum config as `.goreleaser.yml`, but with `draft: false` + `prerelease: true` (instead of `draft: true` + `use_existing_draft: true`). Includes `terraform-registry-manifest.json`.

- **`.github/workflows/slash-command-dispatch.yml`** — Added `pre-release` to the registered commands list.

- **`CONTRIBUTING.md`** — Added "Pre-Release Process" section documenting slash command and manual dispatch triggers, safety checks, and Terraform usage.

- **`.github/pr-welcome-message.md`** — Added pre-release slash command examples to the PR welcome message.

**How it integrates with the existing release process:**
- Release Drafter workflow → creates **draft** releases for stable versions (unchanged)
- This workflow → creates **non-draft prerelease** releases for testing

**Usage from Terraform:**
```hcl
terraform {
  required_providers {
    airbyte = {
      source  = "airbytehq/airbyte"
      version = "1.3.0-rc.1"
    }
  }
}
```

Link to Devin session: https://app.devin.ai/sessions/3dc7cbdd41d149fd900ac3bae835d78a