### PR TITLE
ci: fix pre-release workflow slash command dispatch and git identity

### DIFF
--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -184,6 +184,8 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ inputs.version }}"
+          git config user.name "${{ steps.import_gpg.outputs.name }}"
+          git config user.email "${{ steps.import_gpg.outputs.email }}"
           git tag -a "$VERSION" -m "Pre-release $VERSION"
           git push origin "$VERSION"
 

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Slash Command Dispatch
         id: dispatch
-        uses: peter-evans/slash-command-dispatch@v5
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
         with:
           repository: ${{ github.repository }}
           token: ${{ steps.get-app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Fixes two bugs in the pre-release workflow introduced in #455:

**Bug 1 — Slash command dispatch fails with `Workflow pre-release-command not found`:**
`peter-evans/slash-command-dispatch` v5.0.0 used strict `===` path comparison (`workflow.path === "pre-release-command.yml"`), but the GitHub API returns full paths (`.github/workflows/pre-release-command.yml`), so the match always fails. This was fixed upstream in [v5.0.1](https://github.com/peter-evans/slash-command-dispatch/pull/436) (switched to `endsWith`). Pinning to the v5.0.2 SHA ensures we get this fix and the subsequent pagination fix.

**Bug 2 — `git tag -a` fails with `fatal: empty ident name ... not allowed`:**
GitHub Actions runners have no default git identity. Added `git config user.name/email` using the GPG identity from the `import_gpg` step before the annotated tag creation.

Requested by @aaronsteers.

Link to Devin session: https://app.devin.ai/sessions/3dc7cbdd41d149fd900ac3bae835d78a