### PR TITLE
ci: fix pre-release registry sync and disallow dots in version suffix

### DIFF
--- a/.github/pr-welcome-message.md
+++ b/.github/pr-welcome-message.md
@@ -15,7 +15,7 @@ Your contribution is appreciated. Here are some helpful tips and resources.
 
 ### Pre-Release Commands
 
-- `/pre-release version=v1.3.0-rc.1` - Build and publish a pre-release from this PR's branch
+- `/pre-release version=v1.3.0-rc1` - Build and publish a pre-release from this PR's branch
 
 Pre-releases are published to the Terraform Registry but are **not** the default version. See [CONTRIBUTING.md — Pre-Release Process](CONTRIBUTING.md#pre-release-process) for details.
 

--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -6,14 +6,15 @@
 #
 # Triggers:
 # - Manual workflow_dispatch: From the Actions tab
-# - Slash command: `/pre-release version=v1.3.0-rc.1` on a PR comment
-#   (optionally: `/pre-release version=v1.3.0-rc.1 ref=my-branch`)
+# - Slash command: `/pre-release version=v1.3.0-rc1` on a PR comment
+#   (optionally: `/pre-release version=v1.3.0-rc1 ref=my-branch`)
 #
 # Inputs:
 #
 #   version (REQUIRED): The pre-release version tag.
-#     Must contain a pre-release suffix: -rc.N, -beta.N, -alpha.N, etc.
-#     Examples: v1.3.0-rc.1, v1.3.0-beta.1, v2.0.0-alpha.3
+#     Must contain a pre-release suffix: -rcN, -betaN, -alphaN, etc.
+#     Do NOT use dots in the suffix (e.g. use -rc1, not -rc.1).
+#     Examples: v1.3.0-rc1, v1.3.0-beta1, v2.0.0-alpha3
 #
 #   ref (optional, default: main): The branch, tag, or commit SHA to build from.
 #     Use a feature branch name to test unreleased code, or a PR merge-commit
@@ -40,7 +41,7 @@
 #     required_providers {
 #       airbyte = {
 #         source  = "airbytehq/airbyte"
-#         version = "1.3.0-rc.1"  # note: no 'v' prefix in Terraform
+#         version = "1.3.0-rc1"  # note: no 'v' prefix in Terraform
 #       }
 #     }
 #   }
@@ -52,8 +53,8 @@ on:
     inputs:
       version:
         description: >-
-          Pre-release version tag (e.g. v1.3.0-rc.1, v1.3.0-beta.1).
-          MUST contain a pre-release suffix.
+          Pre-release version tag (e.g. v1.3.0-rc1, v1.3.0-beta1).
+          MUST contain a pre-release suffix (no dots in the suffix).
         required: true
         type: string
       ref:
@@ -126,17 +127,28 @@ jobs:
 
           # Ensure version starts with 'v'
           if [[ ! "$VERSION" =~ ^v ]]; then
-            echo "::error::Version must start with 'v' (e.g. v1.3.0-rc.1). Got: $VERSION"
+            echo "::error::Version must start with 'v' (e.g. v1.3.0-rc1). Got: $VERSION"
             exit 1
           fi
 
-          # Strict semver validation (no leading zeros, valid pre-release identifiers)
-          # Per semver.org: MAJOR.MINOR.PATCH-PRERELEASE where each numeric part has no leading zeros,
-          # and pre-release is dot-separated alphanumeric identifiers (numeric ones must not have leading zeros).
-          SEMVER_RE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(([0-9A-Za-z-]+\.)*[0-9A-Za-z-]+)$'
+          # Strict version validation: vMAJOR.MINOR.PATCH-SUFFIX where:
+          #   - No leading zeros in numeric parts
+          #   - Pre-release suffix is a single alphanumeric+digit token (no dots)
+          #   - e.g. v1.3.0-rc1, v1.3.0-beta1, v2.0.0-alpha3
+          # Dots in the suffix (e.g. -rc.1) are disallowed because the Terraform
+          # Registry convention uses -rcN without dots.
+          SEMVER_RE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([0-9A-Za-z-]+)$'
           if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
-            echo "::error::Invalid semver or missing pre-release suffix. Expected format: vMAJOR.MINOR.PATCH-PRERELEASE (e.g. v1.3.0-rc.1). Got: $VERSION"
+            echo "::error::Invalid version or missing pre-release suffix. Expected format: vMAJOR.MINOR.PATCH-SUFFIX (e.g. v1.3.0-rc1). Got: $VERSION"
+            echo "::error::Do NOT use dots in the suffix (use -rc1, not -rc.1)."
             echo "::error::This workflow is for pre-releases only. Use the Release Drafter for stable releases."
+            exit 1
+          fi
+
+          # Reject dots in the pre-release suffix
+          SUFFIX="${BASH_REMATCH[4]}"
+          if [[ "$SUFFIX" == *.* ]]; then
+            echo "::error::Pre-release suffix must not contain dots. Use e.g. -rc1, not -rc.1. Got suffix: $SUFFIX"
             exit 1
           fi
 
@@ -190,7 +202,7 @@ jobs:
           git push origin "$VERSION"
 
       # ── Build and publish with GoReleaser ───────────────────────────
-      # Uses .goreleaser.prerelease.yml which sets draft=false, prerelease=true.
+      # Uses .goreleaser.prerelease.yml which sets draft=false (no prerelease flag).
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
         with:

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -3,7 +3,9 @@
 # This is a variant of .goreleaser.yml used by the pre-release workflow.
 # Differences from the production config:
 #   - release.draft = false   (immediately visible, not a draft)
-#   - release.prerelease = true (Terraform Registry won't make it the default)
+#   - release.prerelease removed (the semver pre-release suffix in the tag is
+#     enough for Terraform Registry to treat it as non-default; setting the
+#     GitHub "pre-release" flag would actually prevent the Registry from syncing)
 #   - release.use_existing_draft removed (creates a new release)
 #   - changelog.disable removed (includes auto-generated changelog)
 #
@@ -58,7 +60,6 @@ signs:
       - "${artifact}"
 release:
   draft: false
-  prerelease: true
   replace_existing_artifacts: true
   extra_files:
     - glob: 'terraform-registry-manifest.json'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,12 +97,12 @@ Pre-releases let you publish a provider version for testing without making it th
 
 1. **Slash command on a PR** (recommended for PR-based work):
    ```
-   /pre-release version=v1.3.0-rc.1
+   /pre-release version=v1.3.0-rc1
    ```
    This builds from the PR's head branch.
 
 2. **Manual workflow dispatch** (from the [Actions tab](https://github.com/airbytehq/terraform-provider-airbyte/actions/workflows/pre-release-command.yml)):
-   - **version** (required): e.g. `v1.3.0-rc.1`, `v1.3.0-beta.1`. Must be valid semver with a pre-release suffix.
+   - **version** (required): e.g. `v1.3.0-rc1`, `v1.3.0-beta1`. Must be valid semver with a pre-release suffix (no dots in the suffix).
    - **ref** (optional, default: `main`): branch, tag, or commit SHA to build from.
 
 **Safety checks** — the workflow will fail if:
@@ -116,7 +116,7 @@ terraform {
   required_providers {
     airbyte = {
       source  = "airbytehq/airbyte"
-      version = "1.3.0-rc.1"  # no 'v' prefix in Terraform
+      version = "1.3.0-rc1"  # no 'v' prefix in Terraform
     }
   }
 }


### PR DESCRIPTION
## Summary

Two fixes for the pre-release workflow (merged in #457):

1. **Registry sync**: Removed `prerelease: true` from `.goreleaser.prerelease.yml`. The GitHub "Set as a pre-release" flag prevents the Terraform Registry from syncing the release — as documented in CONTRIBUTING.md: *"Do not check 'Set as a pre-release' unless you want to delay Terraform Registry sync."* The semver suffix in the tag (e.g. `-rc1`) is sufficient for the registry to treat it as non-default.

2. **Dot-free suffixes**: Updated the version regex to reject dots in the pre-release suffix (e.g. `v1.3.0-rc.1` → rejected, `v1.3.0-rc1` → accepted). This aligns with the existing convention in the registry where all prior RCs use `rcN` without dots. All examples in workflow comments, `CONTRIBUTING.md`, and `pr-welcome-message.md` updated to match.

Requested by @aaronsteers.

Link to Devin session: https://app.devin.ai/sessions/3dc7cbdd41d149fd900ac3bae835d78a