### PR TITLE
ci: bump semantic-pr-release-drafter to v2.2.0

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -162,7 +162,7 @@ jobs:
 
             - name: Get next version from release drafter
               id: get-version
-              uses: aaronsteers/semantic-pr-release-drafter@v1.1.0
+              uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
               with:
                   dry-run: true
               env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       # Step 1: Create/update draft release (no assets yet)
       - name: Create draft release
-        uses: aaronsteers/semantic-pr-release-drafter@v1.1.0
+        uses: aaronsteers/semantic-pr-release-drafter@v2.2.0
         id: release-drafter
         with:
           name-template: 'v$RESOLVED_VERSION'


### PR DESCRIPTION
## Summary

Bumps `aaronsteers/semantic-pr-release-drafter` from `@v1.1.0` to `@v2.2.0` in both workflows that use it:

- `.github/workflows/release-drafter.yml` (draft-release step)
- `.github/workflows/generate-command.yml` (dry-run "get next version" step)

This is a single-step consumer (no `not-ready` → finalize handoff), so there's no `prepared-release-id` migration — the bump is purely to pick up v2.x, including the new point-in-time `resolved-sha` output and `target_commitish` SHA pin.

No input changes needed: the only 2.0 breaking change was moving the default footer link into the `footer` template, which only affects custom templates that embedded that link — this repo's `template` doesn't, so behavior is unchanged.

Requested by @aaronsteers, following up on aaronsteers/semantic-pr-release-drafter#57 (released in v2.2.0).

Link to Devin session: https://app.devin.ai/sessions/c5aa9e420587440b9e2e5f4e92f65383