### PR TITLE
fix(provider): accept OpenTofu provider address in MoveState

### DIFF
--- a/internal/provider/destination_resource_movestate.go
+++ b/internal/provider/destination_resource_movestate.go
@@ -21,7 +21,7 @@ func (r *DestinationResource) MoveState(ctx context.Context) []resource.StateMov
 				if req.SourceTypeName == "airbyte_destination" {
 					return
 				}
-				if !strings.HasSuffix(req.SourceProviderAddress, "airbytehq/airbyte") {
+				if req.SourceProviderAddress != "airbyte" && !strings.HasSuffix(req.SourceProviderAddress, "airbytehq/airbyte") {
 					return
 				}
 

--- a/internal/provider/destination_resource_movestate.go
+++ b/internal/provider/destination_resource_movestate.go
@@ -21,7 +21,7 @@ func (r *DestinationResource) MoveState(ctx context.Context) []resource.StateMov
 				if req.SourceTypeName == "airbyte_destination" {
 					return
 				}
-				if req.SourceProviderAddress != "airbyte" && !strings.HasSuffix(req.SourceProviderAddress, "airbytehq/airbyte") {
+				if !isAirbyteProviderAddress(req.SourceProviderAddress) {
 					return
 				}
 

--- a/internal/provider/destination_resource_movestate_test.go
+++ b/internal/provider/destination_resource_movestate_test.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDestinationResourceMoveState(t *testing.T) {
+	tests := []struct {
+		name            string
+		sourceTypeName  string
+		providerAddress string
+		matches         bool
+	}{
+		{
+			name:            "bare provider address",
+			sourceTypeName:  "airbyte_destination_postgres",
+			providerAddress: "airbyte",
+			matches:         true,
+		},
+		{
+			name:            "terraform registry provider address",
+			sourceTypeName:  "airbyte_destination_postgres",
+			providerAddress: "registry.terraform.io/airbytehq/airbyte",
+			matches:         true,
+		},
+		{
+			name:            "opentofu registry provider address",
+			sourceTypeName:  "airbyte_destination_postgres",
+			providerAddress: "registry.opentofu.org/airbytehq/airbyte",
+			matches:         true,
+		},
+		{
+			name:            "third-party provider address",
+			sourceTypeName:  "airbyte_destination_postgres",
+			providerAddress: "example.com/notairbytehq/airbyte",
+			matches:         false,
+		},
+		{
+			name:            "generic resource self-move",
+			sourceTypeName:  "airbyte_destination",
+			providerAddress: "airbyte",
+			matches:         false,
+		},
+		{
+			name:            "non-destination resource prefix",
+			sourceTypeName:  "airbyte_source_postgres",
+			providerAddress: "airbyte",
+			matches:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := resource.MoveStateRequest{
+				SourceProviderAddress: tt.providerAddress,
+				SourceRawState:        &tfprotov6.RawState{JSON: []byte("{")},
+				SourceTypeName:        tt.sourceTypeName,
+			}
+			resp := resource.MoveStateResponse{}
+
+			(&DestinationResource{}).MoveState(context.Background())[0].StateMover(context.Background(), req, &resp)
+
+			assert.Equal(t, tt.matches, len(resp.Diagnostics) > 0)
+		})
+	}
+}

--- a/internal/provider/destination_resource_movestate_test.go
+++ b/internal/provider/destination_resource_movestate_test.go
@@ -54,6 +54,8 @@ func TestDestinationResourceMoveState(t *testing.T) {
 		},
 	}
 
+	// The raw state is deliberately invalid JSON, so a parse diagnostic is
+	// raised only when the mover accepts the source resource and provider.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := resource.MoveStateRequest{

--- a/internal/provider/movestate_helpers.go
+++ b/internal/provider/movestate_helpers.go
@@ -3,9 +3,24 @@ package provider
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func isAirbyteProviderAddress(address string) bool {
+	parts := strings.Split(address, "/")
+	switch len(parts) {
+	case 1:
+		return parts[0] == "airbyte"
+	case 2:
+		return parts[0] == "airbytehq" && parts[1] == "airbyte"
+	case 3:
+		return parts[0] != "" && parts[1] == "airbytehq" && parts[2] == "airbyte"
+	default:
+		return false
+	}
+}
 
 func extractJSONString(raw map[string]json.RawMessage, key string) string {
 	v, ok := raw[key]

--- a/internal/provider/movestate_helpers_test.go
+++ b/internal/provider/movestate_helpers_test.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAirbyteProviderAddress(t *testing.T) {
+	tests := []struct {
+		address string
+		matches bool
+	}{
+		{address: "airbyte", matches: true},
+		{address: "airbytehq/airbyte", matches: true},
+		{address: "registry.terraform.io/airbytehq/airbyte", matches: true},
+		{address: "registry.opentofu.org/airbytehq/airbyte", matches: true},
+		{address: "example.com/notairbytehq/airbyte", matches: false},
+		{address: "foo/airbyte", matches: false},
+		{address: "airbytehq/notairbyte", matches: false},
+		{address: "registry.example.com/airbytehq/airbyte/extra", matches: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.address, func(t *testing.T) {
+			assert.Equal(t, tt.matches, isAirbyteProviderAddress(tt.address))
+		})
+	}
+}

--- a/internal/provider/source_resource_movestate.go
+++ b/internal/provider/source_resource_movestate.go
@@ -21,7 +21,7 @@ func (r *SourceResource) MoveState(ctx context.Context) []resource.StateMover {
 				if req.SourceTypeName == "airbyte_source" {
 					return
 				}
-				if !strings.HasSuffix(req.SourceProviderAddress, "airbytehq/airbyte") {
+				if req.SourceProviderAddress != "airbyte" && !strings.HasSuffix(req.SourceProviderAddress, "airbytehq/airbyte") {
 					return
 				}
 
@@ -44,13 +44,13 @@ func (r *SourceResource) MoveState(ctx context.Context) []resource.StateMover {
 				}
 
 				targetState := SourceResourceModel{
-					SourceID:    types.StringValue(sourceID),
-					Name:        extractJSONTypesString(rawState, "name"),
-					WorkspaceID: extractJSONTypesString(rawState, "workspace_id"),
+					SourceID:     types.StringValue(sourceID),
+					Name:         extractJSONTypesString(rawState, "name"),
+					WorkspaceID:  extractJSONTypesString(rawState, "workspace_id"),
 					DefinitionID: extractJSONTypesString(rawState, "definition_id"),
-					SourceType:  extractJSONTypesString(rawState, "source_type"),
-					SecretID:    extractJSONTypesString(rawState, "secret_id"),
-					CreatedAt:   extractJSONInt64(rawState, "created_at"),
+					SourceType:   extractJSONTypesString(rawState, "source_type"),
+					SecretID:     extractJSONTypesString(rawState, "secret_id"),
+					CreatedAt:    extractJSONInt64(rawState, "created_at"),
 				}
 
 				resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetState)...)

--- a/internal/provider/source_resource_movestate.go
+++ b/internal/provider/source_resource_movestate.go
@@ -21,7 +21,7 @@ func (r *SourceResource) MoveState(ctx context.Context) []resource.StateMover {
 				if req.SourceTypeName == "airbyte_source" {
 					return
 				}
-				if req.SourceProviderAddress != "airbyte" && !strings.HasSuffix(req.SourceProviderAddress, "airbytehq/airbyte") {
+				if !isAirbyteProviderAddress(req.SourceProviderAddress) {
 					return
 				}
 

--- a/internal/provider/source_resource_movestate_test.go
+++ b/internal/provider/source_resource_movestate_test.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSourceResourceMoveState(t *testing.T) {
+	tests := []struct {
+		name            string
+		sourceTypeName  string
+		providerAddress string
+		matches         bool
+	}{
+		{
+			name:            "bare provider address",
+			sourceTypeName:  "airbyte_source_postgres",
+			providerAddress: "airbyte",
+			matches:         true,
+		},
+		{
+			name:            "terraform registry provider address",
+			sourceTypeName:  "airbyte_source_postgres",
+			providerAddress: "registry.terraform.io/airbytehq/airbyte",
+			matches:         true,
+		},
+		{
+			name:            "opentofu registry provider address",
+			sourceTypeName:  "airbyte_source_postgres",
+			providerAddress: "registry.opentofu.org/airbytehq/airbyte",
+			matches:         true,
+		},
+		{
+			name:            "third-party provider address",
+			sourceTypeName:  "airbyte_source_postgres",
+			providerAddress: "example.com/notairbytehq/airbyte",
+			matches:         false,
+		},
+		{
+			name:            "generic resource self-move",
+			sourceTypeName:  "airbyte_source",
+			providerAddress: "airbyte",
+			matches:         false,
+		},
+		{
+			name:            "non-source resource prefix",
+			sourceTypeName:  "airbyte_destination_postgres",
+			providerAddress: "airbyte",
+			matches:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := resource.MoveStateRequest{
+				SourceProviderAddress: tt.providerAddress,
+				SourceRawState:        &tfprotov6.RawState{JSON: []byte("{")},
+				SourceTypeName:        tt.sourceTypeName,
+			}
+			resp := resource.MoveStateResponse{}
+
+			(&SourceResource{}).MoveState(context.Background())[0].StateMover(context.Background(), req, &resp)
+
+			assert.Equal(t, tt.matches, len(resp.Diagnostics) > 0)
+		})
+	}
+}

--- a/internal/provider/source_resource_movestate_test.go
+++ b/internal/provider/source_resource_movestate_test.go
@@ -54,6 +54,8 @@ func TestSourceResourceMoveState(t *testing.T) {
 		},
 	}
 
+	// The raw state is deliberately invalid JSON, so a parse diagnostic is
+	// raised only when the mover accepts the source resource and provider.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := resource.MoveStateRequest{


### PR DESCRIPTION
## Summary

Fixes #445: OpenTofu users following the v1 migration guide could not `moved` state from a deprecated typed resource (e.g. `airbyte_destination_postgres`) to the generic `airbyte_destination`, hitting `Error: Unable to Move Resource State`.

Root cause: both state movers only accepted a registry-qualified source provider address.

```go
if !strings.HasSuffix(req.SourceProviderAddress, "airbytehq/airbyte") { return }
```

Terraform passes `registry.terraform.io/airbytehq/airbyte`, but OpenTofu passes the bare short name `airbyte`, so the mover silently declined and the framework surfaced the generic "target resource implementation does not include support" error.

Both movers now share one helper in `movestate_helpers.go` that parses the address into segments instead of suffix-matching, accepting `airbyte`, `airbytehq/airbyte`, and `<any-host>/airbytehq/airbyte` while rejecting near-misses like `example.com/notairbytehq/airbyte` or `foo/airbyte` (the old suffix check would have matched the first of those).

Credit to kenske, who reported the issue and authored the fix in #453; his commit is cherry-picked here with authorship preserved. This internal PR exists so CI can run with repository secrets that fork PRs cannot access (Generate SDK and the semantic-title check fail on forks for permission reasons only).

Also adds the first unit tests on this path — the absence of any test here is why the OpenTofu case shipped broken. They cover, for both movers, bare/Terraform/OpenTofu addresses, a third-party address, the `airbyte_source`/`airbyte_destination` self-move short-circuit, and non-matching type prefixes, plus direct negative cases for the helper.

## Notes

The v1 migration guide (`templates/guides/v1_migration_guide.md.tmpl` → `docs/guides/v1_migration_guide.md`) documents exactly the move that was broken; it is left unchanged here since the version containing this fix is not yet known. A one-line note for OpenTofu users could be added at release time.

## Verification

`go build ./...`, `go vet ./...`, `go test ./internal/provider/... -run MoveState -v` (pass), and `gofmt -l` on the touched files (empty).


Link to Devin session: https://app.devin.ai/sessions/7795ec874611463796a863a3634a0b1f
Requested by: @aaronsteers